### PR TITLE
Update dashboard type definitions to reflect api

### DIFF
--- a/dashboard/src/types/Inverter.ts
+++ b/dashboard/src/types/Inverter.ts
@@ -1,21 +1,22 @@
 import { PVArray } from "./PVArray";
 import {
-  PVSystInverterParameters,
+  SandiaInverterParameters,
   PVWattsInverterParameters
 } from "./InverterParameters";
+import { PVWattsLosses } from "./Losses";
 
 export class Inverter {
   name: string;
   make_model: string;
-  inverter_parameters: PVSystInverterParameters | PVWattsInverterParameters;
-  losses_parameters: object; // eslint-disable-line
+  inverter_parameters: SandiaInverterParameters | PVWattsInverterParameters;
+  losses: PVWattsLosses | null;
   arrays: Array<PVArray>;
 
   constructor({
     name = "New Inverter",
     make_model = "ABC 520",
-    inverter_parameters = new PVSystInverterParameters({}),
-    losses_parameters = {},
+    inverter_parameters = new SandiaInverterParameters({}),
+    losses = null,
     arrays = []
   }: Partial<Inverter>) {
     this.name = name;
@@ -25,12 +26,15 @@ export class Inverter {
         inverter_parameters
       );
     } else {
-      this.inverter_parameters = new PVSystInverterParameters(
+      this.inverter_parameters = new SandiaInverterParameters(
         inverter_parameters
       );
     }
-    this.losses_parameters = losses_parameters;
-
+    if (PVWattsLosses.isInstance(losses)) {
+      this.losses = new PVWattsLosses(losses);
+    } else {
+      this.losses = losses;
+    }
     if (arrays.length == 0) {
       this.arrays = [];
     } else {
@@ -44,7 +48,7 @@ export class Inverter {
       maybe.name != undefined &&
       maybe.make_model != undefined &&
       maybe.inverter_parameters != undefined &&
-      maybe.losses_parameters != undefined &&
+      maybe.losses != undefined &&
       maybe.arrays != undefined
     );
   }

--- a/dashboard/src/types/InverterParameters.ts
+++ b/dashboard/src/types/InverterParameters.ts
@@ -1,4 +1,4 @@
-export class PVSystInverterParameters {
+export class SandiaInverterParameters {
   /* Class mimics the inverter parameters required for the pvsyst model
    * provided by the PVLib inverter database.
    * See: https://github.com/pvlib/pvlib-python/blob/3e25627e34bfd5aadea041da85a30626322b3a99/pvlib/pvsystem.py#L1355
@@ -22,7 +22,6 @@ export class PVSystInverterParameters {
   //DC voltage input. [1/V]
   Pnt: number; //AC power consumed by the inverter at night (night tare). [W]
 
-  // TODO: fix defaults?
   constructor({
     Paco = 0,
     Pdco = 0,
@@ -33,7 +32,7 @@ export class PVSystInverterParameters {
     C2 = 0,
     C3 = 0,
     Pnt = 0
-  }: Partial<PVSystInverterParameters>) {
+  }: Partial<SandiaInverterParameters>) {
     this.Paco = Paco;
     this.Pdco = Pdco;
     this.Vdco = Vdco;
@@ -45,8 +44,8 @@ export class PVSystInverterParameters {
     this.Pnt = Pnt;
   }
 
-  static isInstance(obj: any): obj is PVSystInverterParameters {
-    const maybe = obj as PVSystInverterParameters;
+  static isInstance(obj: any): obj is SandiaInverterParameters {
+    const maybe = obj as SandiaInverterParameters;
     return (
       maybe.Paco != undefined &&
       maybe.Pdco != undefined &&
@@ -62,18 +61,15 @@ export class PVSystInverterParameters {
 }
 
 export class PVWattsInverterParameters {
-  pdc: number;
   pdc0: number;
   eta_inv_nom: number;
   eta_inv_ref: number;
 
   constructor({
-    pdc = 0,
     pdc0 = 0,
     eta_inv_nom = 0.96,
     eta_inv_ref = 0.9637
   }: Partial<PVWattsInverterParameters>) {
-    this.pdc = pdc;
     this.pdc0 = pdc0;
     this.eta_inv_nom = eta_inv_nom;
     this.eta_inv_ref = eta_inv_ref;
@@ -81,7 +77,6 @@ export class PVWattsInverterParameters {
   static isInstance(obj: any): obj is PVWattsInverterParameters {
     const maybe = obj as PVWattsInverterParameters;
     return (
-      maybe.pdc !== undefined &&
       maybe.pdc0 !== undefined &&
       maybe.eta_inv_nom != undefined &&
       maybe.eta_inv_ref != undefined

--- a/dashboard/src/types/Losses.ts
+++ b/dashboard/src/types/Losses.ts
@@ -1,0 +1,54 @@
+export class PVWattsLosses {
+  soiling: number;
+  shading: number;
+  snow: number;
+  mismatch: number;
+  wiring: number;
+  connections: number;
+  lid: number;
+  nameplate_rating: number;
+  age: number;
+  availability: number;
+
+  constructor({
+    soiling = 2.0,
+    shading = 3.0,
+    snow = 0.0,
+    mismatch = 2.0,
+    wiring = 2.0,
+    connections = 0.5,
+    lid = 1.5,
+    nameplate_rating = 1.0,
+    age = 0.0,
+    availability = 3.0
+  }: Partial<PVWattsLosses>) {
+    this.soiling = soiling;
+    this.shading = shading;
+    this.snow = snow;
+    this.mismatch = mismatch;
+    this.wiring = wiring;
+    this.connections = connections;
+    this.lid = lid;
+    this.nameplate_rating = nameplate_rating;
+    this.age = age;
+    this.availability = availability;
+  }
+  static isInstance(obj: any): obj is PVWattsLosses {
+    if (obj == null) {
+      return false;
+    }
+    const maybe = obj as PVWattsLosses;
+    return (
+      maybe.soiling != undefined &&
+      maybe.shading != undefined &&
+      maybe.snow != undefined &&
+      maybe.mismatch != undefined &&
+      maybe.wiring != undefined &&
+      maybe.connections != undefined &&
+      maybe.lid != undefined &&
+      maybe.nameplate_rating != undefined &&
+      maybe.age != undefined &&
+      maybe.availability != undefined
+    );
+  }
+}

--- a/dashboard/src/types/ModuleParameters.ts
+++ b/dashboard/src/types/ModuleParameters.ts
@@ -1,4 +1,5 @@
 export class PVSystModuleParameters {
+  alpha_sc: number;
   gamma_ref: number;
   mu_gamma: number;
   I_L_ref: number;
@@ -6,11 +7,12 @@ export class PVSystModuleParameters {
   R_sh_ref: number;
   R_sh_0: number;
   R_s: number;
-  alpha_sc: number;
-  EgRef: number;
   cells_in_series: number;
+  R_sh_exp: number;
+  EgRef: number;
 
   constructor({
+    alpha_sc = 0,
     gamma_ref = 0,
     mu_gamma = 0,
     I_L_ref = 0,
@@ -18,10 +20,11 @@ export class PVSystModuleParameters {
     R_sh_ref = 0,
     R_sh_0 = 0,
     R_s = 0,
-    alpha_sc = 0,
-    EgRef = 0,
-    cells_in_series = 0
+    cells_in_series = 0,
+    R_sh_exp = 5.5,
+    EgRef = 1.121
   }: Partial<PVSystModuleParameters>) {
+    this.alpha_sc = alpha_sc;
     this.gamma_ref = gamma_ref;
     this.mu_gamma = mu_gamma;
     this.I_L_ref = I_L_ref;
@@ -29,13 +32,15 @@ export class PVSystModuleParameters {
     this.R_sh_ref = R_sh_ref;
     this.R_sh_0 = R_sh_0;
     this.R_s = R_s;
-    this.alpha_sc = alpha_sc;
     this.EgRef = EgRef;
     this.cells_in_series = cells_in_series;
+    this.R_sh_exp = R_sh_exp;
   }
+
   static isInstance(obj: any): obj is PVSystModuleParameters {
     const maybe = obj as PVSystModuleParameters;
     return (
+      maybe.alpha_sc != undefined &&
       maybe.gamma_ref != undefined &&
       maybe.mu_gamma != undefined &&
       maybe.I_L_ref != undefined &&
@@ -43,9 +48,9 @@ export class PVSystModuleParameters {
       maybe.R_sh_ref != undefined &&
       maybe.R_sh_0 != undefined &&
       maybe.R_s != undefined &&
-      maybe.alpha_sc != undefined &&
       maybe.EgRef != undefined &&
-      maybe.cells_in_series != undefined
+      maybe.cells_in_series != undefined &&
+      maybe.R_sh_exp != undefined
     );
   }
 }

--- a/dashboard/src/types/PVArray.ts
+++ b/dashboard/src/types/PVArray.ts
@@ -4,7 +4,7 @@ import {
 } from "./Tracking";
 import {
   PVSystTemperatureParameters,
-  PVWattsTemperatureParameters
+  SAPMTemperatureParameters
 } from "./TemperatureParameters";
 import {
   PVSystModuleParameters,
@@ -18,7 +18,7 @@ export class PVArray {
   temperature_model_parameters:
     | Array<number>
     | PVSystTemperatureParameters
-    | PVWattsTemperatureParameters;
+    | SAPMTemperatureParameters;
   tracking: FixedTrackingParameters | SingleAxisTrackingParameters;
   // PVSyst parameters
   modules_per_string: number;
@@ -58,9 +58,9 @@ export class PVArray {
         temperature_model_parameters
       );
     } else if (
-      PVWattsTemperatureParameters.isInstance(temperature_model_parameters)
+      SAPMTemperatureParameters.isInstance(temperature_model_parameters)
     ) {
-      this.temperature_model_parameters = new PVWattsTemperatureParameters(
+      this.temperature_model_parameters = new SAPMTemperatureParameters(
         temperature_model_parameters
       );
     } else {

--- a/dashboard/src/types/System.ts
+++ b/dashboard/src/types/System.ts
@@ -1,7 +1,6 @@
 import { Inverter } from "./Inverter";
 
 export class System {
-  uuid?: string;
   name: string;
   latitude: number;
   longitude: number;
@@ -10,7 +9,6 @@ export class System {
   inverters: Inverter[];
 
   constructor({
-    uuid,
     name = "New System",
     latitude = 0,
     longitude = 0,
@@ -18,9 +16,6 @@ export class System {
     albedo = 0,
     inverters = []
   }: Partial<System>) {
-    if (uuid != null) {
-      this.uuid = uuid;
-    }
     this.name = name;
     this.latitude = latitude;
     this.longitude = longitude;

--- a/dashboard/src/types/TemperatureParameters.ts
+++ b/dashboard/src/types/TemperatureParameters.ts
@@ -1,19 +1,28 @@
 export class PVSystTemperatureParameters {
   /* Currently only supports pvsyst model */
-  uC: number; // pvlib "Freestanding" default insulated is 15.0
-  uV: number; //        freestanding:00, insulated: 0.0
+  u_c: number; // pvlib "Freestanding" default insulated is 15.0
+  u_v: number; //        freestanding:00, insulated: 0.0
+  eta_m: number;
+  alpha_absorption: number;
 
-  constructor({ uC = 29.0, uV = 0.0 }: Partial<PVSystTemperatureParameters>) {
-    this.uC = uC;
-    this.uV = uV;
+  constructor({
+    u_c = 29.0,
+    u_v = 0.0,
+    eta_m = 0.1,
+    alpha_absorption = 0.9
+  }: Partial<PVSystTemperatureParameters>) {
+    this.u_c = u_c;
+    this.u_v = u_v;
+    this.eta_m = eta_m;
+    this.alpha_absorption = alpha_absorption;
   }
   static isInstance(obj: any): obj is PVSystTemperatureParameters {
     const maybe = obj as PVSystTemperatureParameters;
-    return maybe.uC != undefined && maybe.uV != undefined;
+    return maybe.u_c != undefined && maybe.u_v != undefined;
   }
 }
 
-export class PVWattsTemperatureParameters {
+export class SAPMTemperatureParameters {
   a: number;
   b: number;
   deltaT: number;
@@ -22,13 +31,13 @@ export class PVWattsTemperatureParameters {
     a = 0,
     b = 0,
     deltaT = 0
-  }: Partial<PVWattsTemperatureParameters>) {
+  }: Partial<SAPMTemperatureParameters>) {
     this.a = a;
     this.b = b;
     this.deltaT = deltaT;
   }
-  static isInstance(obj: any): obj is PVWattsTemperatureParameters {
-    const maybe = obj as PVWattsTemperatureParameters;
+  static isInstance(obj: any): obj is SAPMTemperatureParameters {
+    const maybe = obj as SAPMTemperatureParameters;
     return (
       maybe.a != undefined && maybe.b != undefined && maybe.deltaT != undefined
     );

--- a/dashboard/src/types/Tracking.ts
+++ b/dashboard/src/types/Tracking.ts
@@ -16,22 +16,26 @@ export class SingleAxisTrackingParameters {
   axis_tilt: number;
   axis_azimuth: number;
   gcr: number;
+  backtracking: boolean;
 
   constructor({
     axis_tilt = 0,
     axis_azimuth = 0,
-    gcr = 0
+    gcr = 0,
+    backtracking = false
   }: Partial<SingleAxisTrackingParameters>) {
     this.axis_tilt = axis_tilt;
     this.axis_azimuth = axis_azimuth;
     this.gcr = gcr;
+    this.backtracking = backtracking;
   }
   static isInstance(obj: any): obj is SingleAxisTrackingParameters {
     const maybe = obj as SingleAxisTrackingParameters;
     return (
       maybe.axis_tilt !== undefined &&
       maybe.axis_azimuth !== undefined &&
-      maybe.gcr !== undefined
+      maybe.gcr !== undefined &&
+      maybe.backtracking !== undefined
     );
   }
 }

--- a/dashboard/tests/unit/test_types.spec.ts
+++ b/dashboard/tests/unit/test_types.spec.ts
@@ -3,7 +3,7 @@ import { System } from "@/types/System";
 import { Inverter } from "@/types/Inverter";
 import { PVArray } from "@/types/PVArray";
 import {
-  PVSystInverterParameters,
+  SandiaInverterParameters,
   PVWattsInverterParameters
 } from "@/types/InverterParameters";
 import {
@@ -16,8 +16,9 @@ import {
 } from "@/types/Tracking";
 import {
   PVSystTemperatureParameters,
-  PVWattsTemperatureParameters
+  SAPMTemperatureParameters
 } from "@/types/TemperatureParameters";
+import { PVWattsLosses } from "@/types/Losses";
 
 test("Instantiate base system", () => {
   const system = new System({});
@@ -48,7 +49,7 @@ const pvsyst_test_system = {
         C3: 0,
         Pnt: 0
       },
-      losses_parameters: {},
+      losses: null,
       arrays: [
         {
           name: "New Array",
@@ -66,15 +67,18 @@ const pvsyst_test_system = {
             R_s: 0,
             alpha_sc: 0,
             EgRef: 0,
-            cells_in_series: 0
+            cells_in_series: 0,
+            R_sh_exp: 0
           },
           tracking: {
             tilt: 0,
             azimuth: 0
           },
           temperature_model_parameters: {
-            uC: 29,
-            uV: 0
+            u_c: 29,
+            u_v: 0,
+            eta_m: 0,
+            alpha_absorption: 0
           }
         }
       ]
@@ -91,7 +95,7 @@ test("Instantiate pvsyst system from object", () => {
     const inverter = inverters[i];
     expect(inverter instanceof Inverter).toBeTruthy();
     expect(
-      inverter.inverter_parameters instanceof PVSystInverterParameters
+      inverter.inverter_parameters instanceof SandiaInverterParameters
     ).toBeTruthy();
     expect(typeof inverter.make_model).toBe("string");
     const arrays = inverter.arrays;
@@ -127,7 +131,18 @@ const pvwatts_test_system = {
         eta_inv_nom: 0.96,
         eta_inv_ref: 0.9637
       },
-      losses_parameters: {},
+      losses: {
+        soiling: 0,
+        shading: 0,
+        snow: 0,
+        mismatch: 0,
+        wiring: 0,
+        connections: 0,
+        lid: 0,
+        nameplate_rating: 0,
+        age: 0,
+        availability: 0
+      },
       arrays: [
         {
           name: "The Array",
@@ -174,8 +189,7 @@ test("Instantiate pvwatts system from object", () => {
       ).toBeTruthy();
       expect(array.tracking instanceof FixedTrackingParameters).toBeTruthy();
       expect(
-        array.temperature_model_parameters instanceof
-          PVWattsTemperatureParameters
+        array.temperature_model_parameters instanceof SAPMTemperatureParameters
       ).toBeTruthy();
     }
   }
@@ -207,7 +221,8 @@ test("Instantiate Single Axis tracking", () => {
   const tracking_params = {
     axis_tilt: 30.0,
     axis_azimuth: 180.0,
-    gcr: 0.5
+    gcr: 0.5,
+    backtracking: false
   };
   const tracking = new SingleAxisTrackingParameters(tracking_params);
   expect(tracking instanceof SingleAxisTrackingParameters).toBeTruthy();
@@ -222,21 +237,20 @@ test("Empty Inverter init", () => {
   const inverter = new Inverter({});
   expect(inverter.name).toBe("New Inverter");
   expect(inverter.make_model).toBe("ABC 520");
-  expect(inverter.inverter_parameters instanceof PVSystInverterParameters);
-  expect(inverter.losses_parameters).toStrictEqual({});
+  expect(inverter.inverter_parameters instanceof SandiaInverterParameters);
+  expect(inverter.losses).toStrictEqual(null);
   expect(inverter.arrays).toStrictEqual([]);
 });
 
 test("Empty pvwatts inverter parameters init", () => {
   const ip = new PVWattsInverterParameters({});
-  expect(ip.pdc).toBe(0);
   expect(ip.pdc0).toBe(0);
   expect(ip.eta_inv_nom).toBe(0.96);
   expect(ip.eta_inv_ref).toBe(0.9637);
 });
 
 test("Empty pvsyst inverter parameters init", () => {
-  const ip = new PVSystInverterParameters({});
+  const ip = new SandiaInverterParameters({});
   expect(ip.Paco).toBe(0);
   expect(ip.Pdco).toBe(0);
   expect(ip.Vdco).toBe(0);
@@ -289,23 +303,20 @@ describe("Array typeguard", () => {
   });
 });
 describe("Inverter typeguard", () => {
-  test.each([
-    "name",
-    "make_model",
-    "inverter_parameters",
-    "losses_parameters",
-    "arrays"
-  ])("Inverter typeguard missing %p", missing => {
-    const anon_inv: { [key: string]: any } = {
-      name: "name",
-      make_model: "mk_model",
-      inverter_parameters: {},
-      losses_parameters: {},
-      arrays: []
-    };
-    anon_inv[missing] = undefined;
-    expect(Inverter.isInstance(anon_inv)).toBeFalsy();
-  });
+  test.each(["name", "make_model", "inverter_parameters", "losses", "arrays"])(
+    "Inverter typeguard missing %p",
+    missing => {
+      const anon_inv: { [key: string]: any } = {
+        name: "name",
+        make_model: "mk_model",
+        inverter_parameters: {},
+        losses: {},
+        arrays: []
+      };
+      anon_inv[missing] = undefined;
+      expect(Inverter.isInstance(anon_inv)).toBeFalsy();
+    }
+  );
 });
 
 describe("PVSyst inverter parameters typeguard", () => {
@@ -324,7 +335,7 @@ describe("PVSyst inverter parameters typeguard", () => {
         Pnt: 0
       };
       anon_params[missing] = undefined;
-      expect(PVSystInverterParameters.isInstance(anon_params)).toBeFalsy();
+      expect(SandiaInverterParameters.isInstance(anon_params)).toBeFalsy();
     }
   );
 });
@@ -340,7 +351,7 @@ describe("PVWatts inverter parameters typeguard", () => {
         eta_inv_ref: 0
       };
       anon_params[missing] = undefined;
-      expect(PVSystInverterParameters.isInstance(anon_params)).toBeFalsy();
+      expect(SandiaInverterParameters.isInstance(anon_params)).toBeFalsy();
     }
   );
 });
@@ -355,7 +366,8 @@ describe("PVSyst module parameters typeguard", () => {
     "R_s",
     "alpha_sc",
     "EgRef",
-    "cells_in_series"
+    "cells_in_series",
+    "R_sh_exp"
   ])("pvwatts mp typeguard missing %p", missing => {
     const anon_params: { [key: string]: any } = {
       gamma_ref: 0,
@@ -367,7 +379,8 @@ describe("PVSyst module parameters typeguard", () => {
       R_s: 0,
       alpha_sc: 0,
       EgRef: 0,
-      cells_in_series: 0
+      cells_in_series: 0,
+      R_sh_exp: 0
     };
     anon_params[missing] = undefined;
     expect(PVSystModuleParameters.isInstance(anon_params)).toBeFalsy();
@@ -396,7 +409,8 @@ test("Empty pvsyst module parameters init", () => {
   expect(mp.R_sh_0).toBe(0);
   expect(mp.R_s).toBe(0);
   expect(mp.alpha_sc).toBe(0);
-  expect(mp.EgRef).toBe(0);
+  expect(mp.EgRef).toBe(1.121);
+  expect(mp.R_sh_exp).toBe(5.5);
   expect(mp.cells_in_series).toBe(0);
 });
 
@@ -424,7 +438,7 @@ test("Empty pvarray init", () => {
 test("PVWatts array init", () => {
   const array = new PVArray({});
   array.module_parameters = new PVWattsModuleParameters({});
-  array.temperature_model_parameters = new PVWattsTemperatureParameters({});
+  array.temperature_model_parameters = new SAPMTemperatureParameters({});
   array.tracking = new SingleAxisTrackingParameters({});
 
   const pvwattsArray = new PVArray(array);
@@ -438,7 +452,7 @@ test("PVWatts array init", () => {
   ).toBeTruthy();
   expect(
     pvwattsArray.temperature_model_parameters instanceof
-      PVWattsTemperatureParameters
+      SAPMTemperatureParameters
   ).toBeTruthy();
   expect(pvwattsArray.modules_per_string).toBe(0);
   expect(pvwattsArray.strings).toBe(0);
@@ -447,4 +461,18 @@ test("PVWatts array init", () => {
 test("PVarray init with array temperature", () => {
   const pvarray = new PVArray({ temperature_model_parameters: [1, 2, 3] });
   expect(pvarray.temperature_model_parameters).toStrictEqual([1, 2, 3]);
+});
+
+test("Empty Losses init", () => {
+  const losses = new PVWattsLosses({});
+  expect(losses.soiling).toBe(2.0);
+  expect(losses.shading).toBe(3.0);
+  expect(losses.snow).toBe(0.0);
+  expect(losses.mismatch).toBe(2.0);
+  expect(losses.wiring).toBe(2.0);
+  expect(losses.connections).toBe(0.5);
+  expect(losses.lid).toBe(1.5);
+  expect(losses.nameplate_rating).toBe(1.0);
+  expect(losses.age).toBe(0.0);
+  expect(losses.availability).toBe(3.0);
 });


### PR DESCRIPTION
Needs a rebase on #30, includes updates to the classes that mirror the api's `model.py`