### PR TITLE
Construct ModelChain objects from models.PVSystems

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -26,3 +26,7 @@ prometheus-fastapi-instrumentator==5.5.1
 pandas==1.1.4
 pymysql==0.10.1
 sqlalchemy==1.3.20
+pvlib==0.8.0
+numpy==1.19.4
+scipy==1.5.4
+requests==2.24.0

--- a/api/setup.py
+++ b/api/setup.py
@@ -8,9 +8,15 @@ if __name__ == "__main__":
         install_requires=[
             "cryptography",
             "fastapi",
-            "pydantic",
             "httpx",
+            "pandas",
+            "prometheus_fastapi_instrumentator",
+            "pvlib",
+            "pydantic",
+            "pymysql",
             "python-jose",
+            "sentry_sdk",
+            "sqlalchemy",
         ],
         use_scm_version={
             "write_to": "api/solarperformanceinsight_api/_version.py",

--- a/api/solarperformanceinsight_api/models.py
+++ b/api/solarperformanceinsight_api/models.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from typing import Union, List, Optional, Any
 from pydantic import BaseModel, Field
+from enum import Enum
 from pydantic.fields import Undefined
 from pydantic.types import UUID
 
@@ -53,6 +54,11 @@ SYSTEM_EXAMPLE = dict(
                     ),
                 )
             ],
+            airmass_model="kastenyoung1989",
+            aoi_model="no_loss",
+            clearsky_model="ineichen",
+            spectral_model="no_loss",
+            transposition_model="haydavies",
         )
     ],
 )
@@ -350,6 +356,54 @@ class SandiaInverterParameters(BaseModel):
     )
 
 
+class AOIModelEnum(str, Enum):
+    """Model to calculate the incidence angle modifier"""
+
+    no_loss = "no_loss"
+    physical = "physical"
+    ashrae = "ashrae"
+    sapm = "sapm"
+    martin_ruiz = "martin_ruiz"
+
+
+class SpectralModelEnum(str, Enum):
+    """Spectral losses model"""
+
+    no_loss = "no_loss"
+
+
+class ClearskyModelEnum(str, Enum):
+    """Model to estimate clear sky GHI, DNI, DHI"""
+
+    ineichen = "ineichen"
+    haurwitz = "haurwitz"
+    simplified_solis = "simplified_solis"
+
+
+class AirmassModelEnum(str, Enum):
+    """Model to estimate relative airmass at sea level"""
+
+    simple = "simple"
+    kasten1966 = "kasten1966"
+    youngirvine1967 = "youngirvine1967"
+    kastenyoung1989 = "kastenyoung1989"
+    gueymard1993 = "gueymard1993"
+    young1994 = "young1994"
+    pickering2002 = "pickering2002"
+
+
+class TranspositionModelEnum(str, Enum):
+    """Transposition model to determine total in-plane irradiance and the
+    beam, sky diffuse, and ground reflected components"""
+
+    isotropic = "isotropic"
+    klucher = "klucher"
+    haydavies = "haydavies"
+    reindl = "reindl"
+    king = "king"
+    perez = "perez"
+
+
 class Inverter(BaseModel):
     """Parameters for a single inverter feeding into a PV system"""
 
@@ -375,6 +429,11 @@ class Inverter(BaseModel):
         title="Inverter Parameters",
         description="Power conversion parameters for the inverter",
     )
+    airmass_model: AirmassModelEnum = AirmassModelEnum.kastenyoung1989
+    aoi_model: AOIModelEnum = AOIModelEnum.no_loss
+    clearsky_model: ClearskyModelEnum = ClearskyModelEnum.ineichen
+    spectral_model: SpectralModelEnum = SpectralModelEnum.no_loss
+    transposition_model: TranspositionModelEnum = TranspositionModelEnum.haydavies
 
 
 class PVSystem(BaseModel):

--- a/api/solarperformanceinsight_api/models.py
+++ b/api/solarperformanceinsight_api/models.py
@@ -360,7 +360,10 @@ class Inverter(BaseModel):
         description="Make and model of the inverter",
     )
     arrays: List[PVArray] = Field(
-        ..., description="List of PV arrays that are connected to this inverter"
+        ...,
+        description="List of PV arrays that are connected to this inverter",
+        min_items=1,
+        max_items=1,  # only a single array until pvlib 0.9/#1076
     )
     losses: Optional[PVWattsLosses] = Field(
         {}, description="Parameters describing the array losses"
@@ -394,7 +397,7 @@ class PVSystem(BaseModel):
         ..., description="Albedo of the surface around the system", ge=0
     )
     inverters: List[Inverter] = Field(
-        ..., description="List of inverters that make up this system"
+        ..., description="List of inverters that make up this system", min_items=1
     )
 
     class Config:

--- a/api/solarperformanceinsight_api/pvmodeling.py
+++ b/api/solarperformanceinsight_api/pvmodeling.py
@@ -1,0 +1,95 @@
+"""Module to translate models.py into pvlib objects and to run the
+pvlib models.
+"""
+from typing import Union, Tuple, Any, Dict, List
+
+
+from pvlib.location import Location  # type: ignore
+from pvlib.modelchain import ModelChain  # type: ignore
+from pvlib.pvsystem import PVSystem  # type: ignore
+from pvlib.tracking import SingleAxisTracker  # type: ignore
+
+from . import models
+
+
+def construct_location(system: models.PVSystem) -> Location:
+    """Construct a pvlib Location object from a PVSystem"""
+    return Location(
+        latitude=system.latitude,
+        longitude=system.longitude,
+        altitude=system.elevation,
+        name=system.name,
+    )
+
+
+def construct_tracker(
+    tracking: Union[models.FixedTracking, models.SingleAxisTracking]
+) -> Tuple[Union[PVSystem, SingleAxisTracker], Dict[str, Any]]:
+    """Return the appropriate pvlib.pvsystem class and tracking keywords
+    depending on the type of tracking unit"""
+    if isinstance(tracking, models.FixedTracking):
+        return PVSystem, dict(
+            surface_tilt=tracking.tilt, surface_azimuth=tracking.azimuth
+        )
+    elif isinstance(tracking, models.SingleAxisTracking):
+        return SingleAxisTracker, dict(
+            axis_tilt=tracking.axis_tilt,
+            axis_azimuth=tracking.axis_azimuth,
+            gcr=tracking.gcr,
+            backtrack=tracking.backtracking,
+        )
+    else:
+        raise TypeError("Only FixedTracking and SingleAxisTracking currently supported")
+
+
+def construct_pvsystem(
+    inverter: models.Inverter, albedo: float
+) -> Union[PVSystem, SingleAxisTracker]:
+    """Construct a pvlib.pvsystem.PVSystem (or SingleAxisTracker) from an
+    Inverter object"""
+    # only a single array for now until pvlib#1076
+    # otherwise one pvsystem/pvarray per array
+    array = inverter.arrays[0]
+    common_kwargs = dict(
+        albedo=albedo,
+        module=array.make_model,
+        module_parameters=array.module_parameters.dict(),
+        temperature_model_parameters=array.temperature_model_parameters.dict(),
+        modules_per_string=array.modules_per_string,
+        strings_per_inverter=array.strings,
+        inverter=inverter.make_model,
+        inverter_parameters=inverter.inverter_parameters.dict(),
+        name=inverter.name,
+    )
+    if inverter.losses is not None:
+        common_kwargs["losses_parameters"] = inverter.losses.dict()
+    system_model, tracking_kwargs = construct_tracker(array.tracking)
+    return system_model(**tracking_kwargs, **common_kwargs)
+
+
+def extract_pvlib_models(inverter: models.Inverter) -> Dict[str, str]:
+    """Extract the pvlib.modelchain.ModelChain _model keywords from an
+    Inverter definition"""
+    models = dict(inverter._pvlib_models)
+    models.update(
+        {
+            k: v
+            for k, v in inverter.dict().items()
+            if k.endswith("_model") and k != "make_model"
+        }
+    )
+    return models
+
+
+def construct_modelchains(system: models.PVSystem) -> List[ModelChain]:
+    """Construct a pvlib.modelchain.ModelChain object for each Inverter
+    in system"""
+    location = construct_location(system=system)
+    out = []
+    for i, inverter in enumerate(system.inverters):
+        pvsystem = construct_pvsystem(inverter=inverter, albedo=system.albedo)
+        mc = ModelChain(
+            system=pvsystem, location=location, **extract_pvlib_models(inverter)
+        )
+        out.append(mc)
+    return out

--- a/api/solarperformanceinsight_api/pvmodeling.py
+++ b/api/solarperformanceinsight_api/pvmodeling.py
@@ -67,29 +67,15 @@ def construct_pvsystem(
     return system_model(**tracking_kwargs, **common_kwargs)
 
 
-def extract_pvlib_models(inverter: models.Inverter) -> Dict[str, str]:
-    """Extract the pvlib.modelchain.ModelChain _model keywords from an
-    Inverter definition"""
-    models = dict(inverter._pvlib_models)
-    models.update(
-        {
-            k: v
-            for k, v in inverter.dict().items()
-            if k.endswith("_model") and k != "make_model"
-        }
-    )
-    return models
-
-
 def construct_modelchains(system: models.PVSystem) -> List[ModelChain]:
     """Construct a pvlib.modelchain.ModelChain object for each Inverter
     in system"""
     location = construct_location(system=system)
     out = []
-    for i, inverter in enumerate(system.inverters):
+    for inverter in system.inverters:
         pvsystem = construct_pvsystem(inverter=inverter, albedo=system.albedo)
         mc = ModelChain(
-            system=pvsystem, location=location, **extract_pvlib_models(inverter)
+            system=pvsystem, location=location, **dict(inverter._modelchain_models)
         )
         out.append(mc)
     return out

--- a/api/solarperformanceinsight_api/tests/test_pvmodeling.py
+++ b/api/solarperformanceinsight_api/tests/test_pvmodeling.py
@@ -1,0 +1,119 @@
+from inspect import signature
+
+
+from pvlib.location import Location
+from pvlib.modelchain import ModelChain
+from pvlib.pvsystem import PVSystem
+from pvlib.tracking import SingleAxisTracker
+import pytest
+
+
+from solarperformanceinsight_api import models, pvmodeling
+
+
+def test_construct_location(system_def):
+    # verify that location construction does no input validation
+    system_def.longitude = "notanumber"
+    assert isinstance(pvmodeling.construct_location(system_def), Location)
+
+
+@pytest.fixture()
+def fixed_tracking():
+    return models.FixedTracking(tilt=32, azimuth=180.9)
+
+
+def test_construct_tracker_fixed(fixed_tracking):
+    obj, od = pvmodeling.construct_tracker(fixed_tracking)
+    assert obj == PVSystem
+    assert od == {"surface_tilt": 32.0, "surface_azimuth": 180.9}
+
+
+@pytest.fixture()
+def single_axis_tracking():
+    return models.SingleAxisTracking(
+        axis_tilt=0, axis_azimuth=179.8, backtracking=False, gcr=1.8
+    )
+
+
+def test_construct_tracker_single(single_axis_tracking):
+    obj, od = pvmodeling.construct_tracker(single_axis_tracking)
+    assert obj == SingleAxisTracker
+    assert od == {
+        "axis_tilt": 0.0,
+        "axis_azimuth": 179.8,
+        "backtrack": False,
+        "gcr": 1.8,
+    }
+
+
+def test_construct_tracker_err(system_def):
+    with pytest.raises(TypeError):
+        pvmodeling.construct_tracker(system_def)
+
+
+@pytest.fixture(params=["fixed", "single"])
+def either_tracker(request, system_def, fixed_tracking, single_axis_tracking):
+    inv = system_def.inverters[0]
+    if request.param == "fixed":
+        inv.arrays[0].tracking = fixed_tracking
+        return inv, PVSystem
+    else:
+        inv.arrays[0].tracking = single_axis_tracking
+        return inv, SingleAxisTracker
+
+
+def test_construct_pvsystem(either_tracker):
+    inv, cls = either_tracker
+    out = pvmodeling.construct_pvsystem(inv, 0)
+    assert isinstance(out, cls)
+    assert isinstance(out.module_parameters, dict)
+    assert isinstance(out.temperature_model_parameters, dict)
+    assert isinstance(out.inverter_parameters, dict)
+
+
+def test_construct_pvsystem_consistent_kwargs_fixed(system_def, mocker, fixed_tracking):
+    pvsys = mocker.spy(pvmodeling, "PVSystem")
+    inv = system_def.inverters[0]
+    inv.arrays[0].tracking = fixed_tracking
+    out = pvmodeling.construct_pvsystem(inv, 0)
+    assert isinstance(out, PVSystem)
+    sig = signature(PVSystem)
+    params = set(sig.parameters.keys())
+    kwargs = set(pvsys.call_args.kwargs.keys())
+    assert kwargs.issubset(params)
+
+
+def test_extract_pvlib_models(system_def):
+    out = pvmodeling.extract_pvlib_models(system_def.inverters[0])
+    assert out == {
+        "ac_model": "sandia",
+        "dc_model": "pvsyst",
+        "temperature_model": "pvsyst",
+        "airmass_model": "kastenyoung1989",
+        "aoi_model": "no_loss",
+        "clearsky_model": "ineichen",
+        "spectral_model": "no_loss",
+        "transposition_model": "haydavies",
+        "losses_model": "pvwatts",
+    }
+
+
+def test_extract_pvlib_models_consistent_with_modelchain(system_def):
+    models = pvmodeling.extract_pvlib_models(system_def.inverters[0])
+    sig = signature(ModelChain)
+    model_params = {k for k in sig.parameters.keys() if k.endswith("_model")}
+    assert set(models.keys()) == model_params
+
+
+def test_construct_modelchains_fixed(system_def, fixed_tracking):
+    system_def.inverters[0].arrays[0].tracking = fixed_tracking
+    out = pvmodeling.construct_modelchains(system_def)
+    assert len(out) == 1
+    assert isinstance(out[0].system, PVSystem)
+
+
+def test_construct_modelchains_single(system_def, single_axis_tracking):
+    system_def.inverters[0].arrays[0].tracking = single_axis_tracking
+    out = pvmodeling.construct_modelchains(system_def)
+    assert len(out) == 1
+    assert isinstance(out[0].system, SingleAxisTracker)

--- a/api/solarperformanceinsight_api/tests/test_pvmodeling.py
+++ b/api/solarperformanceinsight_api/tests/test_pvmodeling.py
@@ -83,26 +83,12 @@ def test_construct_pvsystem_consistent_kwargs_fixed(system_def, mocker, fixed_tr
     assert kwargs.issubset(params)
 
 
-def test_extract_pvlib_models(system_def):
-    out = pvmodeling.extract_pvlib_models(system_def.inverters[0])
-    assert out == {
-        "ac_model": "sandia",
-        "dc_model": "pvsyst",
-        "temperature_model": "pvsyst",
-        "airmass_model": "kastenyoung1989",
-        "aoi_model": "no_loss",
-        "clearsky_model": "ineichen",
-        "spectral_model": "no_loss",
-        "transposition_model": "haydavies",
-        "losses_model": "pvwatts",
-    }
-
-
-def test_extract_pvlib_models_consistent_with_modelchain(system_def):
-    models = pvmodeling.extract_pvlib_models(system_def.inverters[0])
+def test_inverter_models_consistent_with_modelchain(system_def):
+    # test Inverter._modelchain_models specifies all _model arguments for ModelChain
+    models = {k[0] for k in system_def.inverters[0]._modelchain_models}
     sig = signature(ModelChain)
     model_params = {k for k in sig.parameters.keys() if k.endswith("_model")}
-    assert set(models.keys()) == model_params
+    assert models == model_params
 
 
 def test_construct_modelchains_fixed(system_def, fixed_tracking):

--- a/api/solarperformanceinsight_api/tests/test_storage.py
+++ b/api/solarperformanceinsight_api/tests/test_storage.py
@@ -226,7 +226,7 @@ def test_update_system(
     now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc, microsecond=0)
     if alter:
         system_def.albedo = 999
-        system_def.inverters = []
+        system_def.inverters[0].arrays[0].strings = 3
     with storage_interface.start_transaction() as st:
         st.update_system(system_id, system_def)
         out = st.get_system(system_id)


### PR DESCRIPTION
We'll use the functions in `pvmodeling` later to construct and run the ModelChains. For now, I've restricted the number of arrays per inverter to 1 until pvlib 0.9. I also added:

- the pvlib models corresponding to the parameter sets as the `_pvib_*_model` private attribute, e.g. `SAPMTemperatureParameters._pvlib_temperature_model == 'sapm'`
- the ability to specify the other ModelChain models like aoi, clearsky, etc