### PR TITLE
Move the albedo parameter from a System attribute to a PVArray attribute

### DIFF
--- a/api/solarperformanceinsight_api/models.py
+++ b/api/solarperformanceinsight_api/models.py
@@ -11,7 +11,6 @@ SYSTEM_EXAMPLE = dict(
     latitude=33.98,
     longitude=-115.323,
     elevation=2300,
-    albedo=0.2,
     inverters=[
         dict(
             name="Inverter 1",
@@ -32,6 +31,7 @@ SYSTEM_EXAMPLE = dict(
                 dict(
                     name="Array 1",
                     make_model="Canadian_Solar_Inc__CS5P_220M",
+                    albedo=0.2,
                     modules_per_string=7,
                     strings=5,
                     tracking=dict(
@@ -253,6 +253,9 @@ class PVArray(BaseModel):
     )
     tracking: Union[FixedTracking, SingleAxisTracking] = Field(
         ..., description="Parameters describing single-axis tracking or fixed mounting"
+    )
+    albedo: float = Field(
+        ..., description="Albedo of the surface around the array", ge=0
     )
     modules_per_string: int = Field(
         ...,
@@ -485,9 +488,6 @@ class PVSystem(BaseModel):
     )
     elevation: float = Field(
         ..., description="Elevation of the system above sea level in meters", ge=-300
-    )
-    albedo: float = Field(
-        ..., description="Albedo of the surface around the system", ge=0
     )
     inverters: List[Inverter] = Field(
         ..., description="List of inverters that make up this system", min_items=1

--- a/api/solarperformanceinsight_api/pvmodeling.py
+++ b/api/solarperformanceinsight_api/pvmodeling.py
@@ -42,16 +42,14 @@ def construct_tracker(
         raise TypeError("Only FixedTracking and SingleAxisTracking currently supported")
 
 
-def construct_pvsystem(
-    inverter: models.Inverter, albedo: float
-) -> Union[PVSystem, SingleAxisTracker]:
+def construct_pvsystem(inverter: models.Inverter) -> Union[PVSystem, SingleAxisTracker]:
     """Construct a pvlib.pvsystem.PVSystem (or SingleAxisTracker) from an
     Inverter object"""
     # only a single array for now until pvlib#1076
     # otherwise one pvsystem/pvarray per array
     array = inverter.arrays[0]
     common_kwargs = dict(
-        albedo=albedo,
+        albedo=array.albedo,
         module=array.make_model,
         module_parameters=array.module_parameters.dict(),
         temperature_model_parameters=array.temperature_model_parameters.dict(),
@@ -73,7 +71,7 @@ def construct_modelchains(system: models.PVSystem) -> List[ModelChain]:
     location = construct_location(system=system)
     out = []
     for inverter in system.inverters:
-        pvsystem = construct_pvsystem(inverter=inverter, albedo=system.albedo)
+        pvsystem = construct_pvsystem(inverter=inverter)
         mc = ModelChain(
             system=pvsystem, location=location, **dict(inverter._modelchain_models)
         )

--- a/api/solarperformanceinsight_api/routers/tests/test_systems.py
+++ b/api/solarperformanceinsight_api/routers/tests/test_systems.py
@@ -57,7 +57,7 @@ def test_update_system(
     client, add_example_db_data, system_def, system_id, mocker, alter
 ):
     if alter:
-        system_def.albedo = 999
+        system_def.latitude = 33.99
     update = mocker.spy(storage.StorageInterface, "update_system")
     response = client.post(f"/systems/{system_id}", data=system_def.json())
     assert response.status_code == 201
@@ -66,7 +66,7 @@ def test_update_system(
 
 
 def test_update_other_system(client, add_example_db_data, other_system_id, system_def):
-    system_def.albedo = 999
+    system_def.longitude = -129.83
     system_def.name = "New Name"
     response = client.post(f"/systems/{other_system_id}", data=system_def.json())
     assert response.status_code == 404

--- a/api/solarperformanceinsight_api/tests/test_pvmodeling.py
+++ b/api/solarperformanceinsight_api/tests/test_pvmodeling.py
@@ -64,7 +64,7 @@ def either_tracker(request, system_def, fixed_tracking, single_axis_tracking):
 
 def test_construct_pvsystem(either_tracker):
     inv, cls = either_tracker
-    out = pvmodeling.construct_pvsystem(inv, 0)
+    out = pvmodeling.construct_pvsystem(inv)
     assert isinstance(out, cls)
     assert isinstance(out.module_parameters, dict)
     assert isinstance(out.temperature_model_parameters, dict)
@@ -75,7 +75,7 @@ def test_construct_pvsystem_consistent_kwargs_fixed(system_def, mocker, fixed_tr
     pvsys = mocker.spy(pvmodeling, "PVSystem")
     inv = system_def.inverters[0]
     inv.arrays[0].tracking = fixed_tracking
-    out = pvmodeling.construct_pvsystem(inv, 0)
+    out = pvmodeling.construct_pvsystem(inv)
     assert isinstance(out, PVSystem)
     sig = signature(PVSystem)
     params = set(sig.parameters.keys())

--- a/api/solarperformanceinsight_api/tests/test_storage.py
+++ b/api/solarperformanceinsight_api/tests/test_storage.py
@@ -225,7 +225,7 @@ def test_update_system(
 ):
     now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc, microsecond=0)
     if alter:
-        system_def.albedo = 999
+        system_def.elevation = 999
         system_def.inverters[0].arrays[0].strings = 3
     with storage_interface.start_transaction() as st:
         st.update_system(system_id, system_def)

--- a/dashboard/src/components/model/Array.vue
+++ b/dashboard/src/components/model/Array.vue
@@ -5,6 +5,7 @@
     <br />
     <model-field field-name="name" />
     <model-field field-name="make_model" />
+    <model-field field-name="albedo" />
     <model-field field-name="modules_per_string" />
     <model-field field-name="strings" />
     <b>Tracking:</b>

--- a/dashboard/src/components/model/Arrays.vue
+++ b/dashboard/src/components/model/Arrays.vue
@@ -44,12 +44,27 @@ export default class ArraysView extends Vue {
       modParamClass = PVSystModuleParameters;
       tempParamClass = PVSystTemperatureParameters;
     }
-    this.pvarrays.push(
-      new PVArray({
-        module_parameters: new modParamClass({}),
-        temperature_model_parameters: new tempParamClass({})
-      })
-    );
+
+    let newArray: PVArray;
+    const modParams = new modParamClass({});
+    const tempParams = new tempParamClass({});
+    if (
+      this.pvarrays.length > 0 &&
+      this.pvarrays.every(x => x.albedo === this.pvarrays[0].albedo)
+    ) {
+      const albedo: number = this.pvarrays[0].albedo;
+      newArray = new PVArray({
+        albedo: albedo,
+        module_parameters: modParams,
+        temperature_model_parameters: tempParams
+      });
+    } else {
+      newArray = new PVArray({
+        module_parameters: modParams,
+        temperature_model_parameters: tempParams
+      });
+    }
+    this.pvarrays.push(newArray);
   }
 }
 </script>

--- a/dashboard/src/components/model/System.vue
+++ b/dashboard/src/components/model/System.vue
@@ -4,7 +4,6 @@
     <model-field field-name="latitude" />
     <model-field field-name="longitude" />
     <model-field field-name="elevation" />
-    <model-field field-name="albedo" />
     <inverters-view :inverters="parameters.inverters" :model="model" />
   </div>
 </template>

--- a/dashboard/src/types/PVArray.ts
+++ b/dashboard/src/types/PVArray.ts
@@ -21,6 +21,7 @@ export class PVArray {
     | SAPMTemperatureParameters;
   tracking: FixedTrackingParameters | SingleAxisTrackingParameters;
   // PVSyst parameters
+  albedo: number;
   modules_per_string: number;
   strings: number;
   losses_parameters: object; // eslint-disable-line
@@ -31,12 +32,14 @@ export class PVArray {
     module_parameters = new PVSystModuleParameters({}),
     temperature_model_parameters = new PVSystTemperatureParameters({}),
     tracking = new FixedTrackingParameters({}),
+    albedo = 0,
     modules_per_string = 0,
     strings = 0,
     losses_parameters = {}
   }: Partial<PVArray>) {
     this.name = name;
     this.make_model = make_model;
+    this.albedo = albedo;
     this.modules_per_string = modules_per_string;
     this.strings = strings;
     this.losses_parameters = losses_parameters;
@@ -75,6 +78,7 @@ export class PVArray {
       maybe.module_parameters != undefined &&
       maybe.temperature_model_parameters != undefined &&
       maybe.tracking != undefined &&
+      maybe.albedo != undefined &&
       maybe.modules_per_string != undefined &&
       maybe.strings != undefined &&
       maybe.losses_parameters != undefined

--- a/dashboard/src/types/System.ts
+++ b/dashboard/src/types/System.ts
@@ -5,7 +5,6 @@ export class System {
   latitude: number;
   longitude: number;
   elevation: number;
-  albedo: number;
   inverters: Inverter[];
 
   constructor({
@@ -13,14 +12,12 @@ export class System {
     latitude = 0,
     longitude = 0,
     elevation = 0,
-    albedo = 0,
     inverters = []
   }: Partial<System>) {
     this.name = name;
     this.latitude = latitude;
     this.longitude = longitude;
     this.elevation = elevation;
-    this.albedo = albedo;
     if (inverters.length == 0) {
       this.inverters = [];
     } else {
@@ -34,7 +31,6 @@ export class System {
       maybe.latitude != undefined &&
       maybe.longitude != undefined &&
       maybe.elevation != undefined &&
-      maybe.albedo != undefined &&
       maybe.inverters != undefined
     );
   }

--- a/dashboard/tests/unit/test_model_components.spec.ts
+++ b/dashboard/tests/unit/test_model_components.spec.ts
@@ -291,6 +291,44 @@ describe("Test array", () => {
 });
 
 /*
+ * PV Arrays
+ */
+
+describe("Test adding arrays", () => {
+  const propsData = {
+    pvarrays: new Array(),
+    model: "pvwatts",
+    index: 0
+  };
+  // @ts-expect-error
+  const wrapper = shallowMount(ArraysView, {
+    localVue,
+    propsData,
+    parentComponent,
+    mocks
+  });
+
+  expect(propsData.pvarrays).toHaveLength(0);
+  wrapper.find("button").trigger("click");
+  expect(propsData.pvarrays).toHaveLength(1);
+  const defaultAlbedo = propsData.pvarrays[0].albedo;
+  // change albedo and make sure new array have this value
+  const initAlbedo = 1.2;
+  propsData.pvarrays[0].albedo = initAlbedo;
+  wrapper.find("button").trigger("click");
+  expect(propsData.pvarrays).toHaveLength(2);
+  expect(propsData.pvarrays[1].albedo).toBe(initAlbedo);
+  wrapper.find("button").trigger("click");
+  expect(propsData.pvarrays).toHaveLength(3);
+  expect(propsData.pvarrays[2].albedo).toBe(initAlbedo);
+  // if one array has different albedo, others added have default
+  propsData.pvarrays[1].albedo = 99.8;
+  wrapper.find("button").trigger("click");
+  expect(propsData.pvarrays).toHaveLength(4);
+  expect(propsData.pvarrays[3].albedo).toBe(defaultAlbedo);
+});
+
+/*
  * Inverter
  */
 

--- a/dashboard/tests/unit/test_types.spec.ts
+++ b/dashboard/tests/unit/test_types.spec.ts
@@ -33,7 +33,6 @@ const pvsyst_test_system = {
   latitude: 0,
   longitude: 0,
   elevation: 0,
-  albedo: 0,
   inverters: [
     {
       name: "New Inverter",
@@ -54,6 +53,7 @@ const pvsyst_test_system = {
         {
           name: "New Array",
           make_model: "ABC 123",
+          albedo: 0,
           modules_per_string: 0,
           strings: 0,
           losses_parameters: {},
@@ -120,7 +120,6 @@ const pvwatts_test_system = {
   latitude: 34.0,
   longitude: -110.0,
   elevation: 500,
-  albedo: 0.2,
   inverters: [
     {
       name: "The inverter",
@@ -147,6 +146,7 @@ const pvwatts_test_system = {
         {
           name: "The Array",
           make_model: "ABC 123",
+          albedo: 0.2,
           modules_per_string: 0,
           strings: 0,
           losses_parameters: {},

--- a/db/migrations/20201208224427_altered_system.sql
+++ b/db/migrations/20201208224427_altered_system.sql
@@ -1,0 +1,159 @@
+-- migrate:up
+drop procedure add_example_data;
+create procedure add_example_data ()
+  comment 'Add example data to the database'
+  modifies sql data
+begin
+  set @userid = uuid_to_bin('17fbf1c6-34bd-11eb-af43-f4939feddd82', 1);
+  set @otheruser = uuid_to_bin('972084d4-34cd-11eb-8f13-f4939feddd82', 1);
+  set @sysid = uuid_to_bin('6b61d9ac-2e89-11eb-be2a-4dc7a6bcd0d9', 1);
+  set @othersysid = uuid_to_bin('6513485a-34cd-11eb-8f13-f4939feddd82', 1);
+  set @extime = timestamp('2020-12-01 01:23');
+  set @sysdef = '{
+       "name": "Test PV System",
+       "latitude": 33.98,
+       "longitude": -115.323,
+       "elevation": 2300,
+       "inverters": [
+         {
+           "name": "Inverter 1",
+           "make_model": "ABB__MICRO_0_25_I_OUTD_US_208__208V_",
+           "inverter_parameters": {
+             "Pso": 2.08961,
+             "Paco": 250,
+             "Pdco": 259.589,
+             "Vdco": 40,
+             "C0": -4.1e-05,
+             "C1": -9.1e-05,
+             "C2": 0.000494,
+             "C3": -0.013171,
+             "Pnt": 0.075
+           },
+           "losses": {},
+           "arrays": [
+             {
+               "name": "Array 1",
+               "make_model": "Canadian_Solar_Inc__CS5P_220M",
+               "albedo": 0.2,
+               "modules_per_string": 7,
+               "strings": 5,
+               "tracking": {
+                 "tilt": 20.0,
+                 "azimuth": 180.0
+               },
+               "temperature_model_parameters": {
+                 "u_c": 29.0,
+                 "u_v": 0.0,
+                 "eta_m": 0.1,
+                 "alpha_absorption": 0.9
+               },
+               "module_parameters": {
+                 "alpha_sc": 0.004539,
+                 "gamma_ref": 1.2,
+                 "mu_gamma": -0.003,
+                 "I_L_ref": 5.11426,
+                 "I_o_ref": 8.10251e-10,
+                 "R_sh_ref": 381.254,
+                 "R_s": 1.06602,
+                 "R_sh_0": 400.0,
+                 "cells_in_series": 96
+               }
+             }
+           ]
+         }
+       ]
+     }';
+
+  insert into users (auth0_id, id, created_at) values (
+    'auth0|5fa9596ccf64f9006e841a3a', @userid, @extime
+  ),(
+    'auth0|invalid', @otheruser, @extime
+    );
+  insert into systems (id, user_id, name, definition, created_at, modified_at) values (
+    @sysid, @userid, 'Test PV System', @sysdef, @extime, @extime
+  ),(
+    @othersysid, @otheruser, 'Other system', '{}', @extime, @extime
+    );
+end;
+
+
+
+
+-- migrate:down
+
+drop procedure add_example_data;
+create procedure add_example_data ()
+  comment 'Add example data to the database'
+  modifies sql data
+begin
+  set @userid = uuid_to_bin('17fbf1c6-34bd-11eb-af43-f4939feddd82', 1);
+  set @otheruser = uuid_to_bin('972084d4-34cd-11eb-8f13-f4939feddd82', 1);
+  set @sysid = uuid_to_bin('6b61d9ac-2e89-11eb-be2a-4dc7a6bcd0d9', 1);
+  set @othersysid = uuid_to_bin('6513485a-34cd-11eb-8f13-f4939feddd82', 1);
+  set @extime = timestamp('2020-12-01 01:23');
+  set @sysdef = '{
+       "name": "Test PV System",
+       "latitude": 33.98,
+       "longitude": -115.323,
+       "elevation": 2300,
+       "albedo": 0.2,
+       "inverters": [
+         {
+           "name": "Inverter 1",
+           "make_model": "ABB__MICRO_0_25_I_OUTD_US_208__208V_",
+           "inverter_parameters": {
+             "Pso": 2.08961,
+             "Paco": 250,
+             "Pdco": 259.589,
+             "Vdco": 40,
+             "C0": -4.1e-05,
+             "C1": -9.1e-05,
+             "C2": 0.000494,
+             "C3": -0.013171,
+             "Pnt": 0.075
+           },
+           "losses": {},
+           "arrays": [
+             {
+               "name": "Array 1",
+               "make_model": "Canadian_Solar_Inc__CS5P_220M",
+               "modules_per_string": 7,
+               "strings": 5,
+               "tracking": {
+                 "tilt": 20.0,
+                 "azimuth": 180.0
+               },
+               "temperature_model_parameters": {
+                 "u_c": 29.0,
+                 "u_v": 0.0,
+                 "eta_m": 0.1,
+                 "alpha_absorption": 0.9
+               },
+               "module_parameters": {
+                 "alpha_sc": 0.004539,
+                 "gamma_ref": 1.2,
+                 "mu_gamma": -0.003,
+                 "I_L_ref": 5.11426,
+                 "I_o_ref": 8.10251e-10,
+                 "R_sh_ref": 381.254,
+                 "R_s": 1.06602,
+                 "R_sh_0": 400.0,
+                 "cells_in_series": 96
+               }
+             }
+           ]
+         }
+       ]
+     }';
+
+  insert into users (auth0_id, id, created_at) values (
+    'auth0|5fa9596ccf64f9006e841a3a', @userid, @extime
+  ),(
+    'auth0|invalid', @otheruser, @extime
+    );
+  insert into systems (id, user_id, name, definition, created_at, modified_at) values (
+    @sysid, @userid, 'Test PV System', @sysdef, @extime, @extime
+  ),(
+    @othersysid, @otheruser, 'Other system', '{}', @extime, @extime
+    );
+end;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -163,7 +163,6 @@ begin
        "latitude": 33.98,
        "longitude": -115.323,
        "elevation": 2300,
-       "albedo": 0.2,
        "inverters": [
          {
            "name": "Inverter 1",
@@ -184,6 +183,7 @@ begin
              {
                "name": "Array 1",
                "make_model": "Canadian_Solar_Inc__CS5P_220M",
+               "albedo": 0.2,
                "modules_per_string": 7,
                "strings": 5,
                "tracking": {
@@ -489,5 +489,6 @@ INSERT INTO `schema_migrations` (version) VALUES
   ('20201130184500'),
   ('20201130190000'),
   ('20201130190100'),
-  ('20201202162400');
+  ('20201202162400'),
+  ('20201208224427');
 UNLOCK TABLES;


### PR DESCRIPTION
This is more consistent with the mapping PVArray -> pvlib.pvsystem.PVSystem (and later pvsystem.Array). I'm sure we could also write some javascript to set the albedo of a newly added array to that of the first array on the dashboard. @cwhanse @wholmgren  what do you think of this schema change?