### PR TITLE
Fix system loading

### DIFF
--- a/dashboard/src/components/model/System.vue
+++ b/dashboard/src/components/model/System.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="system">
+    <div v-if="exists" class="model-field">
+      <b>Name:</b>
+      <span>{{ parameters.name }}</span>
+    </div>
     <model-field
+      v-if="!exists"
       :parameters="parameters"
       :errors="errors"
       :definitions="definitions"
@@ -40,6 +45,7 @@ import {
 
 @Component
 export default class SystemView extends ModelBase {
+  @Prop({ default: false }) exists!: boolean;
   @Prop() parameters!: System;
   @Prop() model!: string;
 

--- a/dashboard/src/types/PVArray.ts
+++ b/dashboard/src/types/PVArray.ts
@@ -32,8 +32,8 @@ export class PVArray {
     temperature_model_parameters = new PVSystTemperatureParameters({}),
     tracking = new FixedTrackingParameters({}),
     albedo = 0,
-    modules_per_string = 0,
-    strings = 0
+    modules_per_string = 1,
+    strings = 1
   }: Partial<PVArray>) {
     this.name = name;
     this.make_model = make_model;

--- a/dashboard/src/views/SystemSpec.vue
+++ b/dashboard/src/views/SystemSpec.vue
@@ -174,7 +174,11 @@ export default class SystemSpec extends Vue {
   }
   async saveSystem() {
     const token = await this.$auth.getTokenSilently();
-    const response = await fetch(`/api/systems/`, {
+    let apiPath = "/api/systems/";
+    if (this.systemId) {
+      apiPath = apiPath + this.systemId;
+    }
+    const response = await fetch(apiPath, {
       method: "post",
       body: JSON.stringify(this.system),
       headers: new Headers({

--- a/dashboard/src/views/SystemSpec.vue
+++ b/dashboard/src/views/SystemSpec.vue
@@ -10,11 +10,16 @@
       </div>
       <template v-if="system">
         <h1 v-if="systemId == null">New System</h1>
-        <button @click="displaySummary = !displaySummary">
+        <button
+          class="display-summary"
+          @click="displaySummary = !displaySummary"
+        >
           Display JSON Summary
         </button>
-        <button @click="downloadSystem">Download System JSON</button>
-        <button @click="saveSystem">Save System</button>
+        <button class="download-system" @click="downloadSystem">
+          Download System JSON
+        </button>
+        <button class="save-system" @click="saveSystem">Save System</button>
         <div v-if="displaySummary" class="model-summary">
           <h1>Model Summary</h1>
           <pre>{{ JSON.stringify(system, null, 2) }}</pre>

--- a/dashboard/tests/unit/test_types.spec.ts
+++ b/dashboard/tests/unit/test_types.spec.ts
@@ -427,8 +427,8 @@ test("Empty pvarray init", () => {
   expect(
     pvarray.temperature_model_parameters instanceof PVSystTemperatureParameters
   ).toBeTruthy();
-  expect(pvarray.modules_per_string).toBe(0);
-  expect(pvarray.strings).toBe(0);
+  expect(pvarray.modules_per_string).toBe(1);
+  expect(pvarray.strings).toBe(1);
 });
 test("PVWatts array init", () => {
   const array = new PVArray({});

--- a/dashboard/tests/unit/test_types.spec.ts
+++ b/dashboard/tests/unit/test_types.spec.ts
@@ -449,8 +449,8 @@ test("PVWatts array init", () => {
     pvwattsArray.temperature_model_parameters instanceof
       SAPMTemperatureParameters
   ).toBeTruthy();
-  expect(pvwattsArray.modules_per_string).toBe(0);
-  expect(pvwattsArray.strings).toBe(0);
+  expect(pvwattsArray.modules_per_string).toBe(1);
+  expect(pvwattsArray.strings).toBe(1);
 });
 test("PVarray init with array temperature", () => {
   const pvarray = new PVArray({ temperature_model_parameters: [1, 2, 3] });

--- a/dashboard/tests/unit/test_view_components.spec.ts
+++ b/dashboard/tests/unit/test_view_components.spec.ts
@@ -115,7 +115,7 @@ describe("Test SystemSpec view", () => {
     await flushPromises();
     expect(wrapper.vm.$data.apiErrors).toEqual({});
     expect($router.push).toHaveBeenCalledWith("/systems");
-    expect(fetch).toHaveBeenCalledWith("/api/systems/", expect.anything());
+    expect(fetch).toHaveBeenLastCalledWith("/api/systems/", expect.anything());
   });
   it("Test save existing system", async () => {
     const wrapper = shallowMount(SystemSpec, {
@@ -126,13 +126,16 @@ describe("Test SystemSpec view", () => {
       mocks
     });
     await flushPromises();
+    const saveBtn = wrapper.find("button.save-system");
+    saveBtn.trigger("click");
+    await flushPromises();
+    expect(wrapper.vm.$data.apiErrors).toEqual({});
     expect(wrapper.vm.$data.system).toEqual(system);
-    expect(fetch).toHaveBeenCalledWith(
+    expect(fetch).toHaveBeenLastCalledWith(
       "/api/systems/banana",
       expect.anything()
     );
   });
-
   it("Test save system failure", async () => {
     fetchMock.ok = false;
     const wrapper = shallowMount(SystemSpec, {

--- a/dashboard/tests/unit/test_view_components.spec.ts
+++ b/dashboard/tests/unit/test_view_components.spec.ts
@@ -1,0 +1,58 @@
+import Vue from "vue";
+import Vuex from "vuex";
+import VueRouter from "vue-router";
+import APISpec from "./openapi.json";
+
+import { createLocalVue, mount } from "@vue/test-utils";
+
+import SystemSpec from "@/views/SystemSpec.vue";
+
+import { domain, clientId, audience } from "../../auth_config.json";
+import { authGuard } from "../../src/auth/authGuard";
+import * as auth from "../../src/auth/auth";
+
+import { System } from "@/types/System";
+import { APIValidator } from "@/types/validation/Validator";
+
+const mockedAuthInstance = jest.spyOn(auth, "getInstance");
+
+const user = {
+  email: "testing@solaforecastarbiter.org",
+  email_verified: true,
+  sub: "auth0|5fa9596ccf64f9006e841a3a"
+};
+
+const $auth = {
+  isAuthenticated: true,
+  loading: false,
+  user: user,
+  logout: jest.fn(),
+  loginWithRedirect: jest.fn()
+};
+
+// @ts-expect-error
+mockedAuthInstance.mockImplementation(() => $auth);
+
+const localVue = createLocalVue();
+
+const $validator = new APIValidator();
+$validator.getAPISpec = jest.fn().mockResolvedValue(APISpec);
+
+const mocks = {
+  $auth,
+  $validator
+};
+
+beforeAll(() => {
+  $validator.init();
+});
+
+describe("Test SystemSpec view", () => {
+  it("Test new system", async () => {
+    const wrapper = mount(SystemSpec, {
+      mocks
+    });
+    await Vue.nextTick();
+    expect(wrapper.props("system")).toEqual(new System({}));
+  });
+});

--- a/dashboard/tests/unit/test_view_components.spec.ts
+++ b/dashboard/tests/unit/test_view_components.spec.ts
@@ -115,7 +115,24 @@ describe("Test SystemSpec view", () => {
     await flushPromises();
     expect(wrapper.vm.$data.apiErrors).toEqual({});
     expect($router.push).toHaveBeenCalledWith("/systems");
+    expect(fetch).toHaveBeenCalledWith("/api/systems/", expect.anything());
   });
+  it("Test save existing system", async () => {
+    const wrapper = shallowMount(SystemSpec, {
+      localVue,
+      propsData: {
+        systemId: "banana"
+      },
+      mocks
+    });
+    await flushPromises();
+    expect(wrapper.vm.$data.system).toEqual(system);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/systems/banana",
+      expect.anything()
+    );
+  });
+
   it("Test save system failure", async () => {
     fetchMock.ok = false;
     const wrapper = shallowMount(SystemSpec, {

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -14,6 +14,7 @@
     "sourceMap": true,
     "baseUrl": ".",
     "types": [
+      "node",
       "webpack-env",
       "jest"
     ],


### PR DESCRIPTION
Load systems from the api on page load to make sure the `/system/uuid` endpoint can be hit by knowing the url. The Vuex store is only populated when `/systems` is visited. 

Displays the system name when editing an existing system to avoid conflict response mentioned in #46 

Adds a section that prints apiErrors on post failures. Currently just dumps the response JSON for easier debugging. 

Adds system not found error if a 404 is returned, and doesn't render the form.