### PR TITLE
Inverter browser

### DIFF
--- a/dashboard/src/components/Browser.vue
+++ b/dashboard/src/components/Browser.vue
@@ -76,13 +76,9 @@ export default class DBBrowser extends Vue {
     });
   }
   async loadOptions() {
-    const token = await this.$auth.getTokenSilently();
     const response = await fetch(
-      `/api/parameters/${this.componentName.toLowerCase()}`, {
-        headers: new Headers({
-          Authorization: `Bearer ${token}`
-        })
-    });
+      `/api/parameters/${this.componentName.toLowerCase()}`,
+    );
     const optionList = await response.json()
     this.options = optionList;
     this.selectOptions = optionList;
@@ -93,13 +89,9 @@ export default class DBBrowser extends Vue {
     this.filterOptions();
   }
   async fetchSpec(){
-    const token = await this.$auth.getTokenSilently();
     const response = await fetch(
-      `/api/parameters/${this.componentName.toLowerCase()}/${this.selection}`, {
-        headers: new Headers({
-          Authorization: `Bearer ${token}`
-        })
-    });
+      `/api/parameters/${this.componentName.toLowerCase()}/${this.selection}`
+    );
     const optionList = await response.json();
     return optionList;
   }

--- a/dashboard/src/components/Browser.vue
+++ b/dashboard/src/components/Browser.vue
@@ -47,7 +47,6 @@ export default class DBBrowser extends Vue {
   spec: Record<string, any> = {};
 
   mounted() {
-    console.log("browser mounted");
     this.loadOptions();
   }
   data() {

--- a/dashboard/src/components/Browser.vue
+++ b/dashboard/src/components/Browser.vue
@@ -2,9 +2,9 @@
 <template>
   <div class="db-browser">
     <input v-model="search" v-on:keyup.enter="filterOptions"/>
-    <button @click="filterOptions">Search</button>
-    <button @click="resetSearch">Reset Search</button>
-    <button @click="cancel">Cancel</button>
+    <button class="search" @click="filterOptions">Search</button>
+    <button class="search-reset" @click="resetSearch">Reset Search</button>
+    <button class="cancel" @click="cancel">Cancel</button>
     <div v-if="optionsLoading">
       Loading database...
     </div>
@@ -23,7 +23,7 @@
              <b>{{ k }}:</b> {{ v }}
            </li>
          </ul>
-         <button @click="commit">Use these parameters</button>
+         <button class="commit" @click="commit">Use these parameters</button>
        </div>
        <div v-else>
          Please make a selection.

--- a/dashboard/src/components/Browser.vue
+++ b/dashboard/src/components/Browser.vue
@@ -64,7 +64,8 @@ export default class DBBrowser extends Vue {
   async setFilteredOptions() {
     let opts: Array<string>;
     if (this.search && this.search != "") {
-      opts = this.options.filter(x => x.includes(this.search));
+      const lowerSearch = this.search.toLowerCase();
+      opts = this.options.filter(x => x.toLowerCase().includes(lowerSearch));
     } else {
       opts = this.options;
     }

--- a/dashboard/src/components/Browser.vue
+++ b/dashboard/src/components/Browser.vue
@@ -121,16 +121,4 @@ div.db-browser {
   border: solid 1px #333;
   padding: 1em;
 }
-.help-wrapper {
-  position: absolute;
-  padding: 0.5em;
-  width: 300px;
-  background-color: #fff;
-  border: 1px solid black;
-  border-radius: 5px;
-  box-shadow: 1px 1px 5px #555;
-  z-index: 1;
-  top: 0;
-  left: 100%;
-}
 </style>

--- a/dashboard/src/components/Browser.vue
+++ b/dashboard/src/components/Browser.vue
@@ -1,7 +1,6 @@
-
 <template>
   <div class="db-browser">
-    <input v-model="search" v-on:keyup.enter="filterOptions"/>
+    <input v-model="search" v-on:keyup.enter="filterOptions" />
     <button class="search" @click="filterOptions">Search</button>
     <button class="search-reset" @click="resetSearch">Reset Search</button>
     <button class="cancel" @click="cancel">Cancel</button>
@@ -9,26 +8,29 @@
       Loading database...
     </div>
     <div v-else>
-     <select size=20 v-model="selection" @change="loadSpec">
-       <option v-for="(op, i) in selectOptions" :key="i">{{ op }}</option>
-     </select>
-     <div v-if="specLoading">
-       Loading parameters...
-     </div>
-     <template v-else>
-       <div v-if="this.spec">
-         Parameters for Inverter : <b>{{this.selection }}</b><br />
-         <ul class="parameter-summary">
-           <li v-for="(v, k) in spec" :key="k">
-             <b>{{ k }}:</b> {{ v }}
-           </li>
-         </ul>
-         <button class="commit" @click="commit">Use these parameters</button>
-       </div>
-       <div v-else>
-         Please make a selection.
-       </div>
-     </template>
+      <select size="20" v-model="selection" @change="loadSpec">
+        <option v-for="(op, i) in selectOptions" :key="i">{{ op }}</option>
+      </select>
+      <div v-if="specLoading">
+        Loading parameters...
+      </div>
+      <template v-else>
+        <div v-if="this.spec">
+          Parameters for Inverter :
+          <b>{{ this.selection }}</b>
+          <br />
+          <ul class="parameter-summary">
+            <li v-for="(v, k) in spec" :key="k">
+              <b>{{ k }}:</b>
+              {{ v }}
+            </li>
+          </ul>
+          <button class="commit" @click="commit">Use these parameters</button>
+        </div>
+        <div v-else>
+          Please make a selection.
+        </div>
+      </template>
     </div>
   </div>
 </template>
@@ -41,7 +43,7 @@ export default class DBBrowser extends Vue {
   optionsLoading = true;
   specLoading = false;
   options!: Array<string>;
-  selectOptions: Array<string>= [];
+  selectOptions: Array<string> = [];
   selection!: string;
   search!: string;
   spec: Record<string, any> = {};
@@ -56,10 +58,10 @@ export default class DBBrowser extends Vue {
       selectOptions: this.options,
       selection: this.selection,
       spec: this.spec,
-      search: this.search,
+      search: this.search
     };
   }
-  async setFilteredOptions(){
+  async setFilteredOptions() {
     let opts: Array<string>;
     if (this.search && this.search != "") {
       opts = this.options.filter(x => x.includes(this.search));
@@ -68,27 +70,27 @@ export default class DBBrowser extends Vue {
     }
     return opts;
   }
-  filterOptions(){
+  filterOptions() {
     this.optionsLoading = true;
-    this.setFilteredOptions().then((opts) => {
+    this.setFilteredOptions().then(opts => {
       this.optionsLoading = false;
       this.selectOptions = opts;
     });
   }
   async loadOptions() {
     const response = await fetch(
-      `/api/parameters/${this.componentName.toLowerCase()}`,
+      `/api/parameters/${this.componentName.toLowerCase()}`
     );
-    const optionList = await response.json()
+    const optionList = await response.json();
     this.options = optionList;
     this.selectOptions = optionList;
     this.optionsLoading = false;
   }
-  resetSearch(){
+  resetSearch() {
     this.search = "";
     this.filterOptions();
   }
-  async fetchSpec(){
+  async fetchSpec() {
     const response = await fetch(
       `/api/parameters/${this.componentName.toLowerCase()}/${this.selection}`
     );
@@ -97,7 +99,7 @@ export default class DBBrowser extends Vue {
   }
   loadSpec() {
     this.specLoading = true;
-    this.fetchSpec().then((spec) => {
+    this.fetchSpec().then(spec => {
       this.spec = spec;
       this.specLoading = false;
     });

--- a/dashboard/src/components/Browser.vue
+++ b/dashboard/src/components/Browser.vue
@@ -1,0 +1,103 @@
+
+<template>
+  <div class="db-browser">
+    <button @click="show = true"> Browse Inverter Database</button>
+    <input v-model="search" v-on:input="filterOptions"/>
+    <div v-if="optionsLoading">
+      Loading...
+    </div>
+    <div v-else>
+     <select size=20>
+       <option v-for="(op, i) in options" :key="i">{{ op }}</option>
+     </select>
+     <div v-if="!specLoading">
+       The spec is loaded
+     </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+import { Component, Prop, Vue, Watch } from "vue-property-decorator";
+
+@Component
+export default class DBBrowser extends Vue {
+  @Prop() componentName!: string;
+  show = false;
+  optionsLoading = true;
+  specLoading = true;
+  options!: Array<string>;
+  selectOptions: Array<string>= [];
+  selection!: string;
+  search!: string;
+  spec: Record<string, any> = {};
+
+  mounted() {
+    console.log("browser mounted");
+    this.loadOptions();
+  }
+  data() {
+    return {
+      show: false,
+      options: this.options,
+      selection: this.selection,
+      spec: this.spec,
+      search: this.search
+    };
+  }
+  filterOptions(){
+    let opts: Array<string>;
+    console.log("filtering");
+    this.optionsLoading = true;
+    if (this.search && this.search != "") {
+      opts =this.options.filter(x => x.includes(this.search));
+    } else {
+      opts =this.options;
+    }
+    this.optionsLoading = false;
+    this.selectOptions = opts;
+  }
+  @Watch("search")
+  delaySearch(){
+    setTimeout(() => {
+      this.filterOptions();
+    }, .2)
+  }
+  async loadOptions() {
+    const token = await this.$auth.getTokenSilently();
+    const response = await fetch(
+      `/api/parameters/${this.componentName.toLowerCase()}`, {
+        headers: new Headers({
+          Authorization: `Bearer ${token}`
+        })
+    });
+    const optionList = await response.json()
+    this.options = optionList;
+    this.optionsLoading = false;
+  }
+  loadSpec() {
+    console.log("loadspec called");
+  }
+  commit() {
+    this.$emit("parameters-selected", this.spec);
+  }
+}
+</script>
+
+<style scoped>
+div.help {
+  display: inline-block;
+  position: relative;
+}
+.help-wrapper {
+  position: absolute;
+  padding: 0.5em;
+  width: 300px;
+  background-color: #fff;
+  border: 1px solid black;
+  border-radius: 5px;
+  box-shadow: 1px 1px 5px #555;
+  z-index: 1;
+  top: 0;
+  left: 100%;
+}
+</style>

--- a/dashboard/src/components/Browser.vue
+++ b/dashboard/src/components/Browser.vue
@@ -1,24 +1,28 @@
 
 <template>
   <div class="db-browser">
-    <input v-model="search" />
+    <input v-model="search" v-on:keyup.enter="filterOptions"/>
     <button @click="filterOptions">Search</button>
     <button @click="resetSearch">Reset Search</button>
     <button @click="cancel">Cancel</button>
     <div v-if="optionsLoading">
-      Loading...
+      Loading database...
     </div>
     <div v-else>
      <select size=20 v-model="selection" @change="loadSpec">
        <option v-for="(op, i) in selectOptions" :key="i">{{ op }}</option>
      </select>
      <div v-if="specLoading">
-       Loading Parameters
+       Loading parameters...
      </div>
      <template v-else>
        <div v-if="this.spec">
          Parameters for Inverter : <b>{{this.selection }}</b><br />
-         <pre>{{ this.spec }} </pre>
+         <ul class="parameter-summary">
+           <li v-for="(v, k) in spec" :key="k">
+             <b>{{ k }}:</b> {{ v }}
+           </li>
+         </ul>
          <button @click="commit">Use these parameters</button>
        </div>
        <div v-else>

--- a/dashboard/src/components/model/Inverter.vue
+++ b/dashboard/src/components/model/Inverter.vue
@@ -18,6 +18,7 @@
     <b>Inverter Parameters:</b>
     <br />
     <inverter-parameters
+      @parameters-selected="loadInverterParameters"
       :parameters="parameters.inverter_parameters"
       :model="model"
     />
@@ -82,6 +83,13 @@ export default class InverterView extends ModelBase {
     this.$validator
       .validate(this.apiComponentName, inverter)
       .then(this.setValidationResult);
+  }
+
+  loadInverterParameters(parameters: Record<string, any>) {
+    // only supported for pvsyst model
+    this.parameters.inverter_parameters = new SandiaInverterParameters(
+      parameters
+    );
   }
 }
 </script>

--- a/dashboard/src/components/model/InverterParameters.vue
+++ b/dashboard/src/components/model/InverterParameters.vue
@@ -2,13 +2,16 @@
   <div class="inverter-parameters">
     <template v-if="model == 'pvsyst'">
       <!-- Render an inverter browser for pvsyst model -->
-      <button class="show-browser" @click="showBrowser=true">Browse Inverter Database</button>
+      <button class="show-browser" @click="showBrowser = true">
+        Browse Inverter Database
+      </button>
       <db-browser
         v-on="$listeners"
-        @parameters-selected="showBrowser=false"
-        @cancel-selection="showBrowser=false"
+        @parameters-selected="showBrowser = false"
+        @cancel-selection="showBrowser = false"
         v-if="showBrowser"
-        :componentName="apiComponentName" />
+        :componentName="apiComponentName"
+      />
       <br />
     </template>
     <!-- If user selects something other than User Supplied, display the

--- a/dashboard/src/components/model/InverterParameters.vue
+++ b/dashboard/src/components/model/InverterParameters.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="inverter-parameters">
-    <b>Parameter source:</b>
-    <db-browser :componentName="apiComponentName" />
-    <br />
+    <template v-if="model = 'pvsyst'">
+      <!-- Render an inverter browser for pvsyst model -->
+      <button @click="showBrowser=true">Browse Inverter Database</button>
+      <db-browser
+        @parameters-selected="loadInverter"
+        @cancel-selection="showBrowser=false"
+        v-if="showBrowser"
+        :componentName="apiComponentName" />
+      <br />
+    </template>
     <!-- If user selects something other than User Supplied, display the
          list of inverters from the db. This should probably be it's own
          component with some search functionality built in
      -->
-    <div v-if="parameterSource !== 'User Supplied'">
-      <b>Select an Inverter:</b>
-      <select @change="loadInverter" name="inverter-list">
-        <option v-for="p in parameterOptions" :key="p">{{ p }}</option>
-      </select>
-      <br />
-    </div>
     <div v-if="model == 'pvsyst'">
       <model-field
         :parameters="parameters"
@@ -108,25 +108,19 @@ export default class InverterParametersView extends ModelBase {
   @Prop() parameters!: SandiaInverterParameters | PVWattsInverterParameters;
   @Prop() model!: string;
   @Prop({ default: null }) selectedInverter!: string;
+  showBrowser = false;
 
   data() {
     return {
-      parameterSource: "User Supplied"
+      parameterSource: "User Supplied",
+      showBrowser: this.showBrowser
     };
   }
 
-  loadInverter(event: any) {
-    // TODO: load inverter from correct source based on selected model.
-    console.log(event.target.value);
-  }
-
-  get parameterOptions() {
-    // Return a list of parameter options based on currently selected model
-    if (this.model == "pvsyst") {
-      return ["PVSystInverter_0", "PVSystInverter_1"];
-    } else {
-      return ["PVWattsInverter_0", "PVWattsInverter_1"];
-    }
+  loadInverter(parameters: Record<string, any>) {
+    this.showBrowser = false;
+    // only supported for pvsyst model
+    this.parameters = new SandiaInverterParameters(parameters);
   }
 
   get apiComponentName() {

--- a/dashboard/src/components/model/InverterParameters.vue
+++ b/dashboard/src/components/model/InverterParameters.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="inverter-parameters">
-    <template v-if="model = 'pvsyst'">
+    <template v-if="model == 'pvsyst'">
       <!-- Render an inverter browser for pvsyst model -->
       <button @click="showBrowser=true">Browse Inverter Database</button>
       <db-browser

--- a/dashboard/src/components/model/InverterParameters.vue
+++ b/dashboard/src/components/model/InverterParameters.vue
@@ -2,7 +2,7 @@
   <div class="inverter-parameters">
     <template v-if="model == 'pvsyst'">
       <!-- Render an inverter browser for pvsyst model -->
-      <button @click="showBrowser=true">Browse Inverter Database</button>
+      <button class="show-browser" @click="showBrowser=true">Browse Inverter Database</button>
       <db-browser
         v-on="$listeners"
         @parameters-selected="showBrowser=false"

--- a/dashboard/src/components/model/InverterParameters.vue
+++ b/dashboard/src/components/model/InverterParameters.vue
@@ -4,7 +4,8 @@
       <!-- Render an inverter browser for pvsyst model -->
       <button @click="showBrowser=true">Browse Inverter Database</button>
       <db-browser
-        @parameters-selected="loadInverter"
+        v-on="$listeners"
+        @parameters-selected="showBrowser=false"
         @cancel-selection="showBrowser=false"
         v-if="showBrowser"
         :componentName="apiComponentName" />
@@ -115,12 +116,6 @@ export default class InverterParametersView extends ModelBase {
       parameterSource: "User Supplied",
       showBrowser: this.showBrowser
     };
-  }
-
-  loadInverter(parameters: Record<string, any>) {
-    this.showBrowser = false;
-    // only supported for pvsyst model
-    this.parameters = new SandiaInverterParameters(parameters);
   }
 
   get apiComponentName() {

--- a/dashboard/src/components/model/InverterParameters.vue
+++ b/dashboard/src/components/model/InverterParameters.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="inverter-parameters">
     <b>Parameter source:</b>
-    <select v-model="parameterSource" name="parameter-source">
-      <option>User Supplied</option>
-      <option>Browse Database</option>
-    </select>
+    <db-browser :componentName="apiComponentName" />
     <br />
     <!-- If user selects something other than User Supplied, display the
          list of inverters from the db. This should probably be it's own

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -15,6 +15,7 @@ import { Auth0Plugin } from "./auth/auth";
 // Import all components for global registration
 import ArrayView from "@/components/model/Array.vue";
 import ArraysView from "@/components/model/Arrays.vue";
+import DBBrowser from "@/components/Browser.vue";
 import HelpPopup from "@/components/Help.vue";
 import Home from "@/views/Home.vue";
 import InverterView from "@/components/model/Inverter.vue";
@@ -76,6 +77,7 @@ const store = new Vuex.Store(spiStore);
 // Register components globally.
 Vue.component("array-view", ArrayView);
 Vue.component("arrays-view", ArraysView);
+Vue.component("db-browser", DBBrowser);
 Vue.component("help", HelpPopup);
 Vue.component("home", Home);
 Vue.component("inverter-view", InverterView);

--- a/dashboard/tests/unit/test_helper_components.spec.ts
+++ b/dashboard/tests/unit/test_helper_components.spec.ts
@@ -31,7 +31,7 @@ import DBBrowser from "@/components/Browser.vue";
 import { SandiaInverterParameters } from "@/types/InverterParameters";
 
 const mockInverters = ["inva", "invb", "invc"];
-const mockParams = new SandiaInverterParameters({})
+const mockParams = new SandiaInverterParameters({});
 describe("Test Browser Component", () => {
   beforeEach(() => {
     fetchMock = {
@@ -45,8 +45,8 @@ describe("Test Browser Component", () => {
   it("test load options", async () => {
     const wrapper = mount(DBBrowser, {
       propsData: {
-        componentName: "SandiaInverterParameters",
-      },
+        componentName: "SandiaInverterParameters"
+      }
     });
     await flushPromises();
     expect(wrapper.vm.$data.options).toEqual(mockInverters);
@@ -59,7 +59,7 @@ describe("Test Browser Component", () => {
 
     await flushPromises();
 
-    expect(wrapper.vm.$data.selectOptions).toEqual(['inva']);
+    expect(wrapper.vm.$data.selectOptions).toEqual(["inva"]);
     const option = wrapper.findAll("option");
     expect(option).toHaveLength(1);
     expect(wrapper.find("ul").exists()).toBe(false);
@@ -80,15 +80,15 @@ describe("Test Browser Component", () => {
     wrapper.find("button.commit").trigger("click");
     await flushPromises();
     // @ts-expect-error
-    expect(wrapper.emitted("parameters-selected")[0]).toStrictEqual(
-      [mockParams]
-    );
+    expect(wrapper.emitted("parameters-selected")[0]).toStrictEqual([
+      mockParams
+    ]);
   });
   it("test emit cancel", async () => {
     const wrapper = mount(DBBrowser, {
       propsData: {
-        componentName: "SandiaInverterParameters",
-      },
+        componentName: "SandiaInverterParameters"
+      }
     });
     await flushPromises();
     expect(wrapper.vm.$data.options).toEqual(mockInverters);

--- a/dashboard/tests/unit/test_model_components.spec.ts
+++ b/dashboard/tests/unit/test_model_components.spec.ts
@@ -985,14 +985,14 @@ describe("Test inverter parameters", () => {
       parameters: new Inverter({
         inverter_parameters: new SandiaInverterParameters({
           Paco: 10,
-          Pdco: 10,
-        }),
+          Pdco: 10
+        })
       }),
       model: "pvsyst"
     };
     fetchMock = {
       json: jest.fn().mockResolvedValue(["inverter1"])
-    }
+    };
     // @ts-expect-error
     const wrapper = mount(InverterView, {
       localVue,
@@ -1031,10 +1031,7 @@ describe("Test inverter parameters", () => {
     await flushPromises();
 
     expect(wrapper.find("div.db-browser").exists()).toBe(false);
-
-
   });
-
 });
 /*
  * System


### PR DESCRIPTION
Adds an inverter database browser popup that show up when the user clicks a "browse inverter database button". The list of inverter names is shown and searchable, however search requires the user to click "search" or hit enter instead of reacting to their typing. Due to the number of objects available in this and future databases, updating reactively would be an issue. 
Once the user selects an inverter, they can preview the parameters and click "use these parameters" to import them into the form.
![Screenshot from 2020-12-14 11-56-31](https://user-images.githubusercontent.com/21206164/102123080-ab053000-3e03-11eb-9bd2-15b04c3a9836.png)
![Screenshot from 2020-12-14 11-56-44](https://user-images.githubusercontent.com/21206164/102123087-ae002080-3e03-11eb-90de-f5588bc1c084.png)

