### PR TITLE
Cypress config in local env file

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,12 +47,6 @@ jobs:
 
       - name: Cypress run
         uses: cypress-io/github-action@v2
-        env:
-          CYPRESS_AUTH_AUDIENCE: "https://app.solarperformanceinsight.org/api"
-          CYPRESS_AUTH_URL: "https://solarperformanceinsight.us.auth0.com/oauth/token"
-          CYPRESS_AUTH_CLIENT_ID: "G7Cag1LvitX0sOUOrYz03xv6xyl3bE9s"
-          CYPRESS_AUTH_PASSWORD: "Thepassword123!"
-          CYPRESS_AUTH_USERNAME: "testing@solarperformanceinsight.org"
         with:
           start: "npm run serve -- --port 8001, uvicorn solarperformanceinsight_api.main:app"
           wait-on: "http://localhost:8001, http://localhost:8000/docs"

--- a/.gitignore
+++ b/.gitignore
@@ -179,4 +179,3 @@ pnpm-debug.log*
 dashboard/cypress/videos
 dashboard/cypress/screenshots
 dashboard/cypress/plugins
-dashboard/cypress.env.json

--- a/dashboard/cypress.env.json
+++ b/dashboard/cypress.env.json
@@ -1,0 +1,7 @@
+{
+ "AUTH_URL": "https://solarperformanceinsight.us.auth0.com/oauth/token",
+ "AUTH_CLIENT_ID": "G7Cag1LvitX0sOUOrYz03xv6xyl3bE9s",
+ "AUTH_AUDIENCE": "https://app.solarperformanceinsight.org/api",
+ "AUTH_USERNAME": "testing@solarperformanceinsight.org",
+ "AUTH_PASSWORD": "Thepassword123!"
+}


### PR DESCRIPTION
Realized that if we don't need secrets for the cypress tests, we can store them in a `cypress.env.json` so that cypress tests can be run locally without having to export a bunch of env vars or keep track of the env file separately. 