### PR TITLE
Fix job result timeseries selection.

### DIFF
--- a/dashboard/src/components/jobs/JobResults.vue
+++ b/dashboard/src/components/jobs/JobResults.vue
@@ -149,7 +149,7 @@ export default class JobResults extends Vue {
           this.system,
           result.definition.schema_path
         );
-        const label = `${systemComponent.name} ${result.definition.type}`;
+        const label = `${systemComponent.name} ${result.definition.type} (${result.definition.schema_path})`;
         // @ts-expect-error
         labelled[result.object_id] = label;
       });

--- a/dashboard/src/components/jobs/data/Timeseries.vue
+++ b/dashboard/src/components/jobs/data/Timeseries.vue
@@ -87,7 +87,11 @@ export default class TimeseriesPlot extends Vue {
   }
   @Watch("timeseriesData")
   changeData() {
+    const originalCol = this.column;
     this.column = this.availableFields[0];
+    if (this.column == originalCol) {
+      this.redraw();
+    }
   }
   downloadData(contentType: string) {
     this.$emit("download-timeseries", contentType);


### PR DESCRIPTION
closes #116 
Appended the schema path to the end of each timeseries result to differentiate system components with the same name.

The timeseries plotting component was watching for updates to the Arrow table and setting the currently selected column to the first variable in the table, changing columns triggered the redraw through a watch function on column. When switching between similar results, the column was never actually updated.
I've updated the function that watches for arrow table changes to trigger a redraw if the column has not changed.