### PR TITLE
Update job result polling

### DIFF
--- a/dashboard/src/api/jobs.ts
+++ b/dashboard/src/api/jobs.ts
@@ -64,3 +64,6 @@ export async function getSingleResult(
 export async function compute(token: string, jobId: string) {
   return jobsRequest(token, "post", null, null, `${jobId}/compute`);
 }
+export async function jobStatus(token: string, jobId: string) {
+  return jobsRequest(token, "get", null, null, `${jobId}/status`);
+}

--- a/dashboard/src/components/jobs/JobHandler.vue
+++ b/dashboard/src/components/jobs/JobHandler.vue
@@ -425,6 +425,8 @@ export default class JobHandler extends Vue {
     if (this.job) {
       if (this.jobStatus == "incomplete") {
         return "Data Upload Required";
+      } else if (this.jobStatus == "error") {
+        return "An error occurred";
       } else if (this.jobStatus == "prepared") {
         return "Ready For Calculation";
       } else {
@@ -442,6 +444,8 @@ export default class JobHandler extends Vue {
         return "Ready";
       } else if (this.jobStatus == "queued") {
         return "Queued";
+      } else if (this.jobStatus == "error") {
+        return "An error occurred";
       } else {
         return "Calculation Not Submitted";
       }

--- a/dashboard/src/components/jobs/JobResults.vue
+++ b/dashboard/src/components/jobs/JobResults.vue
@@ -49,6 +49,9 @@ Component for handling display/download of job results.
       <template v-else-if="jobStatus == 'error'">
         An error occured while processing the calculation.
       </template>
+      <template v-else-if="jobStatus == 'complete'">
+        Calculation is complete. Results are loading.
+      </template>
       <template v-else>
         Calculation has not been submitted.
       </template>
@@ -102,9 +105,10 @@ export default class JobResults extends Vue {
   }
   async awaitCompletion(token: string) {
     // fetch the job status until we find something meaningful to report.
-    const statusRequest = await Jobs.jobStatus(token, this.job.object_id).then(
-      response => response.json()
-    );
+    const statusRequest = await Jobs.jobStatus(
+      token,
+      this.job.object_id
+    ).then(response => response.json());
     const jobStatus = statusRequest.status;
     if (jobStatus != this.jobStatus) {
       // Emit an event to reload the job when the status has changed so that

--- a/dashboard/src/components/jobs/JobResults.vue
+++ b/dashboard/src/components/jobs/JobResults.vue
@@ -53,9 +53,6 @@ Component for handling display/download of job results.
         Calculation has not been submitted.
       </template>
     </div>
-    <div v-if="errors">
-      {{ errors }}
-    </div>
   </div>
 </template>
 <script lang="ts">
@@ -83,7 +80,6 @@ export default class JobResults extends Vue {
   timeseriesData!: any;
   summaryData!: Record<string, any>;
   loadedSummaryData!: Array<string>;
-  errors!: string;
 
   // for tracking the setTimeout callback used for reloading the job
   timeout!: any;
@@ -119,8 +115,8 @@ export default class JobResults extends Vue {
       // load results when complete
       this.initializeResults();
     } else if (jobStatus == "error") {
-      // Render an error and discontinue polling
-      this.errors = "Job calculation failed.";
+      // discontinue polling
+      return;
     } else {
       // Wait 1 second and poll for status update
       this.timeout = setTimeout(this.awaitCompletion.bind(this, token), 1000);


### PR DESCRIPTION
- Polls `/jobs/<jobid>/status` and emits an event for the parent JobHandler to reload the whole job when the status changes.
- Stop polling on an error result.
- Add simple error message rendering section to the results section.
- Updates the submit/results status in the sidebar when an error has occurred.