### PR TITLE
Rearrange model

### DIFF
--- a/dashboard/src/components/jobs/parameters/JobParams.vue
+++ b/dashboard/src/components/jobs/parameters/JobParams.vue
@@ -55,13 +55,14 @@
             <br />
             <div class="ml-1 mt-1">
               <input
-                id="cell"
-                value="cell"
+                id="air"
+                value="air"
                 type="radio"
                 v-model="temperature_type"
               />
-              <label for="cell">
-                Cell temperature is included in my data.
+              <label for="air">
+                Calculate cell temperature from irradiance, air temperature, and
+                windspeed in my data.
               </label>
               <br />
               <input
@@ -76,14 +77,13 @@
               </label>
               <br />
               <input
-                id="air"
-                value="air"
+                id="cell"
+                value="cell"
                 type="radio"
                 v-model="temperature_type"
               />
-              <label for="air">
-                Calculate cell temperature from irradiance, air temperature, and
-                windspeed in my data.
+              <label for="cell">
+                Cell temperature is included in my data.
               </label>
               <br />
             </div>
@@ -171,7 +171,7 @@ export default class JobParameters extends Vue {
       irradiance_type: "standard",
       apiErrors: {},
       errorState: false,
-      temperature_type: "cell",
+      temperature_type: "air",
       jobId: null
     };
   }

--- a/dashboard/src/components/model/Array.vue
+++ b/dashboard/src/components/model/Array.vue
@@ -6,6 +6,32 @@
       :definitions="definitions"
       field-name="name"
     />
+    <b>Tracking:</b>
+    <input
+      v-model="tracking"
+      class="fixed_tracking"
+      type="radio"
+      v-on:change="changeTracking"
+      value="fixed"
+    />
+    Fixed
+    <input
+      :disabled="numArrays > 1"
+      v-model="tracking"
+      class="single_axis_tracking"
+      type="radio"
+      v-on:change="changeTracking"
+      value="singleAxis"
+    />
+    Single Axis
+    <span v-if="numArrays > 1" class="warning-text">
+      Only supported for single array inverter.
+    </span>
+    <tracking-parameters
+      :tracking="tracking"
+      :parameters="parameters.tracking"
+    />
+    <br />
     <model-field
       :parameters="parameters"
       :errors="errors"
@@ -41,32 +67,6 @@
       :definitions="definitions"
       field-name="albedo"
     />
-    <b>Tracking:</b>
-    <input
-      v-model="tracking"
-      class="fixed_tracking"
-      type="radio"
-      v-on:change="changeTracking"
-      value="fixed"
-    />
-    Fixed
-    <input
-      :disabled="numArrays > 1"
-      v-model="tracking"
-      class="single_axis_tracking"
-      type="radio"
-      v-on:change="changeTracking"
-      value="singleAxis"
-    />
-    Single Axis
-    <span v-if="numArrays > 1" class="warning-text">
-      Only supported for single array inverter.
-    </span>
-    <tracking-parameters
-      :tracking="tracking"
-      :parameters="parameters.tracking"
-    />
-    <br />
     <model-field
       :parameters="parameters"
       :errors="errors"

--- a/dashboard/tests/unit/jobs/test_jobparameters.spec.ts
+++ b/dashboard/tests/unit/jobs/test_jobparameters.spec.ts
@@ -111,7 +111,7 @@ describe("Test Job Parameters", () => {
       time_parameters: defaultTimeParams,
       weather_granularity: "system",
       irradiance_type: "effective",
-      temperature_type: "cell"
+      temperature_type: "air"
     });
     expect(wrapper.findComponent(TimeParameters).exists()).toBe(true);
     wrapper.find("button").trigger("click");


### PR DESCRIPTION
- closes #128 Moves the box for tracking parameters above modules per string.
- closes #127 Rearranges temperature options for jobs as suggested.