### PR TITLE
Handle Job Errors

### DIFF
--- a/dashboard/src/components/jobs/JobHandler.vue
+++ b/dashboard/src/components/jobs/JobHandler.vue
@@ -380,8 +380,6 @@ export default class JobHandler extends Vue {
           }
         }
         this.step = theStep;
-      } else if (this.jobStatus == "error") {
-        this.step = "error";
       } else if (this.jobStatus == "prepared") {
         this.step = "calculate";
       } else {

--- a/dashboard/src/components/jobs/JobResults.vue
+++ b/dashboard/src/components/jobs/JobResults.vue
@@ -177,16 +177,6 @@ export default class JobResults extends Vue {
       console.log("Couldn't load results");
     }
   }
-  async loadErrors() {
-    const token = await this.$auth.getTokenSilently();
-    const response = await Jobs.getResults(token, this.jobId);
-    if (response.ok) {
-      this.errors = await response.json();
-      this.loading = false;
-    } else {
-      console.log("Couldn't load Errors");
-    }
-  }
   async loadResultData(dataId: string) {
     const token = await this.$auth.getTokenSilently();
     const response = await Jobs.getSingleResult(

--- a/dashboard/src/components/jobs/JobResults.vue
+++ b/dashboard/src/components/jobs/JobResults.vue
@@ -3,25 +3,38 @@ Component for handling display/download of job results.
 -->
 <template>
   <div v-if="job">
-    <div v-if="results" class="job-results">
-      <h2 class="monthly-summary">Monthly Summary</h2>
-      <div v-if="summaryData">
-        <summary-table :tableData="summaryData"></summary-table>
+    <div v-if="results">
+      <div v-if="jobStatus == 'complete'" class="job-results">
+        <h2 class="monthly-summary">Monthly Summary</h2>
+        <div v-if="summaryData">
+          <summary-table :tableData="summaryData"></summary-table>
+        </div>
+        <h2 class="data-summary">Results and Measurements</h2>
+        <p>
+          Below is a table of the results of this calculation and user uploaded
+          measurements.
+          <timeseries-table
+            :job="job"
+            :resultObjects="results"
+            :dataObjects="job.data_objects"
+          />
+        </p>
+        <h2 class="timeseries-header">Timeseries Results</h2>
+        <div v-if="results">
+          <custom-plot :resultObjects="results" :job="job" />
+        </div>
       </div>
-      <h2 class="data-summary">Results and Measurements</h2>
-      <p>
-        Below is a table of the results of this calculation and user uploaded
-        measurements.
-        <timeseries-table
-          :job="job"
-          :resultObjects="results"
-          :dataObjects="job.data_objects"
-        />
-      </p>
-
-      <h2 class="timeseries-header">Timeseries Results</h2>
-      <div v-if="results">
-        <custom-plot :resultObjects="results" :job="job" />
+      <div v-else>
+        Errors occured while processing the calculation.
+        <ul v-if="errors">
+          <li
+            v-for="(error, errno) in errors"
+            :key="errno"
+            class="warning-text"
+          >
+            {{ error.error.details }}
+          </li>
+        </ul>
       </div>
     </div>
     <div v-else>
@@ -30,9 +43,6 @@ Component for handling display/download of job results.
       </template>
       <template v-else-if="jobStatus == 'running'">
         The calculation is running and will be ready soon.
-      </template>
-      <template v-else-if="jobStatus == 'error'">
-        An error occured while processing the calculation.
       </template>
       <template v-else-if="jobStatus == 'complete'">
         Calculation is complete. Results are loading.
@@ -71,6 +81,7 @@ export default class JobResults extends Vue {
   results!: Array<Record<string, any>>;
   timeseriesData!: any;
   summaryData!: Record<string, any>;
+  errors!: Record<string, Record<string, any>>;
 
   // for tracking the setTimeout callback used for reloading the job
   timeout!: any;
@@ -103,12 +114,9 @@ export default class JobResults extends Vue {
       // JobHandler can react accordingly.
       this.$emit("reload-job");
     }
-    if (jobStatus == "complete") {
+    if (jobStatus == "complete" || jobStatus == "error") {
       // load results when complete
       this.initializeResults();
-    } else if (jobStatus == "error") {
-      // discontinue polling
-      return;
     } else {
       // Wait 1 second and poll for status update
       this.timeout = setTimeout(this.awaitCompletion.bind(this, token), 1000);
@@ -116,7 +124,11 @@ export default class JobResults extends Vue {
   }
   initializeResults() {
     this.loadResults().then(() => {
-      this.loadSummaryResults();
+      if (this.jobStatus == "complete") {
+        this.loadSummaryResults();
+      } else {
+        this.loadErrorResults();
+      }
     });
   }
   data() {
@@ -126,7 +138,7 @@ export default class JobResults extends Vue {
       selected: "",
       timeseriesData: null,
       summaryData: {},
-      errors: null
+      errors: {}
     };
   }
   get labelledSummaryResults() {
@@ -165,6 +177,16 @@ export default class JobResults extends Vue {
       console.log("Couldn't load results");
     }
   }
+  async loadErrors() {
+    const token = await this.$auth.getTokenSilently();
+    const response = await Jobs.getResults(token, this.jobId);
+    if (response.ok) {
+      this.errors = await response.json();
+      this.loading = false;
+    } else {
+      console.log("Couldn't load Errors");
+    }
+  }
   async loadResultData(dataId: string) {
     const token = await this.$auth.getTokenSilently();
     const response = await Jobs.getSingleResult(
@@ -173,6 +195,15 @@ export default class JobResults extends Vue {
       dataId
     ).then(response => response.arrayBuffer());
     return Table.from([new Uint8Array(response)]);
+  }
+  async loadErrorResultsData(dataId: string) {
+    const token = await this.$auth.getTokenSilently();
+    const response = await Jobs.getSingleResult(
+      token,
+      this.jobId,
+      dataId
+    ).then(response => response.json());
+    return response;
   }
   async loadTimeseriesData() {
     if (this.selected != "") {
@@ -205,6 +236,16 @@ export default class JobResults extends Vue {
       const object_id = this.labelledSummaryResults[summaryType];
       this.loadResultData(object_id).then(data => {
         this.$set(this.summaryData, summaryType, data);
+      });
+    }
+  }
+  loadErrorResults() {
+    const errorResults = this.results.filter((result: Record<string, any>) => {
+      return result.definition.type == "error message";
+    });
+    for (const result of errorResults) {
+      this.loadErrorResultsData(result.object_id).then(data => {
+        this.$set(this.errors, result.object_id, data);
       });
     }
   }

--- a/dashboard/src/components/jobs/data/TimeseriesResultsTable.vue
+++ b/dashboard/src/components/jobs/data/TimeseriesResultsTable.vue
@@ -103,12 +103,16 @@ export default class TimeseriesTable extends Vue {
     if (this.resultObjects) {
       for (const resultObject of this.resultObjects) {
         const resultType = resultObject.definition.type;
+        if (resultType == "error message") {
+          continue;
+        }
         const path = resultObject.definition.schema_path;
         const systemComponent = indexSystemFromSchemaPath(
           this.job.definition.system_definition,
           path
         );
         const componentName = `${systemComponent.name} (${path})`;
+        console.log(resultType);
         allData.push({
           source: "Results",
           metadata: resultObject,

--- a/dashboard/src/components/jobs/data/TimeseriesResultsTable.vue
+++ b/dashboard/src/components/jobs/data/TimeseriesResultsTable.vue
@@ -112,7 +112,6 @@ export default class TimeseriesTable extends Vue {
           path
         );
         const componentName = `${systemComponent.name} (${path})`;
-        console.log(resultType);
         allData.push({
           source: "Results",
           metadata: resultObject,

--- a/dashboard/tests/unit/jobs/test_jobhandler.spec.ts
+++ b/dashboard/tests/unit/jobs/test_jobhandler.spec.ts
@@ -620,7 +620,7 @@ describe("Test JobHandler", () => {
 
     // @ts-expect-error
     handler.vm.setStep();
-    expect(handler.vm.$data.step).toBe("error");
+    expect(handler.vm.$data.step).toBe("results");
 
     handler.vm.$data.job.status.status = "prepared";
 


### PR DESCRIPTION
closes #159 
If a job status is "error", displays the errors reported by the API on the results page, This should handle errors that occur during computation. Screenshot of a current `Not Implemented` placeholder error.
![Screenshot from 2021-03-03 13-41-41](https://user-images.githubusercontent.com/21206164/109869602-5618cf00-7c26-11eb-88f5-cbf53e195ca8.png)
