### PR TITLE
Browser rounding

### DIFF
--- a/dashboard/src/components/Browser.vue
+++ b/dashboard/src/components/Browser.vue
@@ -115,9 +115,17 @@ export default class DBBrowser extends Vue {
   loadSpec() {
     this.specLoading = true;
     this.fetchSpec().then(spec => {
-      this.spec = spec;
+      this.spec = this.adjustValues(spec);
       this.specLoading = false;
     });
+  }
+  adjustValues(spec: Record<string, number>) {
+    const adjusted: Record<string, number> = {};
+    for (const key in spec) {
+      // 12 points is the highest precision in the database
+      adjusted[key] = parseFloat(spec[key].toFixed(12));
+    }
+    return adjusted;
   }
   commit() {
     this.$emit("parameters-selected", {

--- a/dashboard/tests/unit/test_helper_components.spec.ts
+++ b/dashboard/tests/unit/test_helper_components.spec.ts
@@ -87,7 +87,7 @@ describe("Test Browser Component", () => {
     wrapper.find("button.commit").trigger("click");
     await flushPromises();
     // @ts-expect-error
-    expect(wrapper.emitted("parameters-selected")[0]).toStrictEqual([
+    expect(wrapper.emitted("parameters-selected")[0]).toEqual([
       {
         parameters: mockParams,
         name: "inva"
@@ -108,5 +108,26 @@ describe("Test Browser Component", () => {
     wrapper.find("button.cancel").trigger("click");
     await flushPromises();
     expect(wrapper.emitted("cancel-selection")).toBeTruthy();
+  });
+  it("test adjust values", async () => {
+    const wrapper = mount(DBBrowser, {
+      propsData: {
+        componentName: "SandiaInverterParameters"
+      }
+    });
+    expect(
+      // @ts-expect-error
+      wrapper.vm.adjustValues({
+        v1: 0.0004940000000000001,
+        v2: -0.014925999999999998,
+        v3: 0.123456789012,
+        v4: 12345678901234.123
+      })
+    ).toEqual({
+      v1: 0.000494,
+      v2: -0.014926,
+      v3: 0.123456789012,
+      v4: 12345678901234.123
+    });
   });
 });


### PR DESCRIPTION
Remove the floating point noise from the values in inverter/module database values as requested in #88.
Creates a fixed-precision decimal string and parses a float from the value. The first few results from the inverter database match the csv in pvlib. 

Before rounding values: 
![Screenshot from 2021-03-08 12-05-06](https://user-images.githubusercontent.com/21206164/110368646-91d8dd80-8006-11eb-91f3-805e1a9fb441.png)

After rounding values:
![Screenshot from 2021-03-08 12-06-12](https://user-images.githubusercontent.com/21206164/110368754-b59c2380-8006-11eb-9d27-290c567d7bbc.png)

