### PR TITLE
Drop leap day in actual data if not in predicted

### DIFF
--- a/api/solarperformanceinsight_api/compute.py
+++ b/api/solarperformanceinsight_api/compute.py
@@ -555,10 +555,10 @@ def _get_missing_leap_days(dfs: List[pd.DataFrame]) -> Set[dt.datetime]:
             if not feb29.any():
                 continue
             nans = pd.isnull(grp.loc[feb29])
-            # if not all data is nan on feb29, don't drop
-            if not nans.all().all():
-                continue
-            thisset |= set(grp.index[feb29].to_list())
+            # all data is nan on feb29, so user did not include date in
+            # upload (likely) or just specified nan values (less likely)
+            if nans.all().all():
+                thisset |= set(grp.index[feb29].to_list())
         per_df.append(thisset)
     out = per_df[0]
     out.intersection_update(*per_df[1:])

--- a/api/solarperformanceinsight_api/compute.py
+++ b/api/solarperformanceinsight_api/compute.py
@@ -6,7 +6,7 @@ from itertools import zip_longest
 import json
 import logging
 from statistics import mean
-from typing import Callable, Generator, Union, List, Tuple, Optional
+from typing import Callable, Generator, Union, List, Tuple, Optional, Set
 from uuid import UUID
 
 
@@ -439,7 +439,11 @@ def run_performance_job(job: models.StoredJob, si: storage.StorageInterface):
     save_results_to_db(job.object_id, result_list, si)
 
 
-def _get_actual_monthly_energy(job: models.StoredJob, si: storage.StorageInterface):
+def _get_actual_monthly_energy(
+    job: models.StoredJob,
+    si: storage.StorageInterface,
+    missing_leap_days: List[dt.datetime] = [],
+):
     # performance granularity validation means there won't be system level
     # perfromance and inverter level that you wouldn't want to sum
     performance_data_ids = [
@@ -457,7 +461,13 @@ def _get_actual_monthly_energy(job: models.StoredJob, si: storage.StorageInterfa
     )[
         "performance"
     ]  # type: ignore
-    actual_energy = actual_performance.resample("1h").mean()  # type: ignore
+    # drop times from missing_leap_days
+    new_index = actual_performance.index.difference(
+        pd.DatetimeIndex(missing_leap_days)  # type: ignore
+    )
+    actual_energy = (
+        actual_performance.reindex(new_index).resample("1h").mean()  # type: ignore
+    )
     actual_monthly_energy = (
         actual_energy.groupby(actual_energy.index.month).sum().reindex(months)
     )
@@ -529,9 +539,29 @@ def _get_temp(
     return tuple(out)
 
 
+def _get_missing_leap_days(df: Optional[pd.DataFrame]) -> Set[dt.datetime]:
+    # if df is None:
+    #    return set()
+    if not df.index.is_leap_year.any():  # type: ignore
+        return set()
+    leap_df = df.loc[df.index.is_leap_year]  # type: ignore
+    out = set()
+    for _, grp in leap_df.groupby(leap_df.index.year):  # type: ignore
+        feb29 = grp.index.is_leap_year & (grp.index.dayofyear == 60)  # type: ignore
+        if not feb29.any():
+            continue
+        nans = pd.isnull(grp.loc[feb29])
+        # if not all data is nan on feb29, don't drop
+        if not nans.all().all():
+            continue
+        out |= set(grp.index[feb29].to_list())
+    return out
+
+
 def _calculate_weather_adjusted_predicted_performance(
     job: models.StoredJob, si: storage.StorageInterface
-) -> Tuple[List[DBResult], pd.Series]:
+) -> Tuple[List[DBResult], pd.Series, List[dt.datetime]]:
+    missing_leap_days = set()
     job_params: models.ComparePredictedActualJobParameters = (
         job.definition.parameters  # type: ignore
     )
@@ -669,14 +699,21 @@ def _calculate_weather_adjusted_predicted_performance(
                 data=pac_adj,
             )
         )
-    return results_list, total_ref_pac
+        for rw in ref_weather:
+            missing_leap_days |= _get_missing_leap_days(rw)
+
+    return results_list, total_ref_pac, list(missing_leap_days)
 
 
 def compare_predicted_and_actual(job: models.StoredJob, si: storage.StorageInterface):
-    results_list, total_ref_pac = _calculate_weather_adjusted_predicted_performance(
-        job, si
+    (
+        results_list,
+        total_ref_pac,
+        missing_leap_days,
+    ) = _calculate_weather_adjusted_predicted_performance(job, si)
+    actual_monthly_energy, months = _get_actual_monthly_energy(
+        job, si, missing_leap_days
     )
-    actual_monthly_energy, months = _get_actual_monthly_energy(job, si)
     ref_energy = total_ref_pac.resample("1h").mean()  # type: ignore
     ref_monthly_energy = (
         ref_energy.groupby(ref_energy.index.month).sum().reindex(months)

--- a/api/solarperformanceinsight_api/tests/test_compute.py
+++ b/api/solarperformanceinsight_api/tests/test_compute.py
@@ -1208,3 +1208,79 @@ def test_compare_predicted_and_actual_cec_module_temp_as_expected(
         .loc["2021-02-01 11:00:00-07:00", "performance"]
         > 1070
     )
+
+
+@pytest.mark.parametrize(
+    "inp,exp",
+    [
+        (
+            pd.DataFrame(
+                {"performance": [0, float("NaN"), 0]},
+                index=[
+                    pd.Timestamp("2020-02-28T23:00Z"),
+                    pd.Timestamp("2020-02-29T23:00Z"),
+                    pd.Timestamp("2020-03-01T23:00Z"),
+                ],
+            ),
+            {pd.Timestamp("2020-02-29T23:00Z")},
+        ),
+        (
+            pd.DataFrame(
+                {"performance": [0, float("NaN"), 0]},
+                index=[
+                    pd.Timestamp("2020-02-28T23:00-07:00"),
+                    pd.Timestamp("2020-02-29T23:00-07:00"),
+                    pd.Timestamp("2020-03-01T23:00-07:00"),
+                ],
+            ),
+            {pd.Timestamp("2020-02-29T23:00-07:00")},
+        ),
+        (
+            pd.DataFrame(
+                {"performance": [0, float("NaN"), 0]},
+                index=[
+                    pd.Timestamp("2020-02-28T23:00Z"),
+                    pd.Timestamp("2020-02-29T01:00Z"),
+                    pd.Timestamp("2020-02-29T02:00Z"),
+                ],
+            ),
+            set(),
+        ),
+        (
+            pd.DataFrame(
+                {"performance": [0, float("NaN"), 0]},
+                index=[
+                    pd.Timestamp("2021-02-28T23:00Z"),
+                    pd.Timestamp("2021-03-01T01:00Z"),
+                    pd.Timestamp("2021-03-01T02:00Z"),
+                ],
+            ),
+            set(),
+        ),
+        (
+            pd.DataFrame(
+                {"performance": [0, float("NaN"), 0]},
+                index=[
+                    pd.Timestamp("2016-02-29T00:00Z"),
+                    pd.Timestamp("2020-02-29T01:00Z"),
+                    pd.Timestamp("2024-02-29T02:00Z"),
+                ],
+            ),
+            {pd.Timestamp("2020-02-29T01:00Z")},
+        ),
+        (
+            pd.DataFrame(
+                {"performance": [0, float("NaN"), float("NaN")]},
+                index=[
+                    pd.Timestamp("2016-02-29T00:00Z"),
+                    pd.Timestamp("2020-02-29T01:00Z"),
+                    pd.Timestamp("2024-02-29T02:00Z"),
+                ],
+            ),
+            {pd.Timestamp("2020-02-29T01:00Z"), pd.Timestamp("2024-02-29T02:00Z")},
+        ),
+    ],
+)
+def test_get_missing_leap_days(inp, exp):
+    out = compute._get_missing_leap_days(inp)
+    assert out == exp

--- a/api/solarperformanceinsight_api/tests/test_compute.py
+++ b/api/solarperformanceinsight_api/tests/test_compute.py
@@ -1214,73 +1214,272 @@ def test_compare_predicted_and_actual_cec_module_temp_as_expected(
     "inp,exp",
     [
         (
-            pd.DataFrame(
-                {"performance": [0, float("NaN"), 0]},
-                index=[
-                    pd.Timestamp("2020-02-28T23:00Z"),
-                    pd.Timestamp("2020-02-29T23:00Z"),
-                    pd.Timestamp("2020-03-01T23:00Z"),
-                ],
-            ),
+            [
+                pd.DataFrame(
+                    {"performance": [0, float("NaN"), 0]},
+                    index=[
+                        pd.Timestamp("2020-02-28T23:00Z"),
+                        pd.Timestamp("2020-02-29T23:00Z"),
+                        pd.Timestamp("2020-03-01T23:00Z"),
+                    ],
+                )
+            ],
             {pd.Timestamp("2020-02-29T23:00Z")},
         ),
         (
-            pd.DataFrame(
-                {"performance": [0, float("NaN"), 0]},
-                index=[
-                    pd.Timestamp("2020-02-28T23:00-07:00"),
-                    pd.Timestamp("2020-02-29T23:00-07:00"),
-                    pd.Timestamp("2020-03-01T23:00-07:00"),
-                ],
-            ),
+            [
+                pd.DataFrame(
+                    {"performance": [0, float("NaN"), 0]},
+                    index=[
+                        pd.Timestamp("2020-02-28T23:00-07:00"),
+                        pd.Timestamp("2020-02-29T23:00-07:00"),
+                        pd.Timestamp("2020-03-01T23:00-07:00"),
+                    ],
+                )
+            ],
             {pd.Timestamp("2020-02-29T23:00-07:00")},
         ),
         (
-            pd.DataFrame(
-                {"performance": [0, float("NaN"), 0]},
-                index=[
-                    pd.Timestamp("2020-02-28T23:00Z"),
-                    pd.Timestamp("2020-02-29T01:00Z"),
-                    pd.Timestamp("2020-02-29T02:00Z"),
-                ],
-            ),
+            [
+                pd.DataFrame(
+                    {"performance": [0, float("NaN"), 0]},
+                    index=[
+                        pd.Timestamp("2020-02-28T23:00Z"),
+                        pd.Timestamp("2020-02-29T01:00Z"),
+                        pd.Timestamp("2020-02-29T02:00Z"),
+                    ],
+                )
+            ],
             set(),
         ),
         (
-            pd.DataFrame(
-                {"performance": [0, float("NaN"), 0]},
-                index=[
-                    pd.Timestamp("2021-02-28T23:00Z"),
-                    pd.Timestamp("2021-03-01T01:00Z"),
-                    pd.Timestamp("2021-03-01T02:00Z"),
-                ],
-            ),
+            [
+                pd.DataFrame(
+                    {"performance": [0, float("NaN"), 0]},
+                    index=[
+                        pd.Timestamp("2021-02-28T23:00Z"),
+                        pd.Timestamp("2021-03-01T01:00Z"),
+                        pd.Timestamp("2021-03-01T02:00Z"),
+                    ],
+                )
+            ],
             set(),
         ),
         (
-            pd.DataFrame(
-                {"performance": [0, float("NaN"), 0]},
-                index=[
-                    pd.Timestamp("2016-02-29T00:00Z"),
-                    pd.Timestamp("2020-02-29T01:00Z"),
-                    pd.Timestamp("2024-02-29T02:00Z"),
-                ],
-            ),
+            [
+                pd.DataFrame(
+                    {"performance": [0, float("NaN"), 0]},
+                    index=[
+                        pd.Timestamp("2016-02-29T00:00Z"),
+                        pd.Timestamp("2020-02-29T01:00Z"),
+                        pd.Timestamp("2024-02-29T02:00Z"),
+                    ],
+                )
+            ],
             {pd.Timestamp("2020-02-29T01:00Z")},
         ),
         (
-            pd.DataFrame(
-                {"performance": [0, float("NaN"), float("NaN")]},
-                index=[
-                    pd.Timestamp("2016-02-29T00:00Z"),
-                    pd.Timestamp("2020-02-29T01:00Z"),
-                    pd.Timestamp("2024-02-29T02:00Z"),
-                ],
-            ),
+            [
+                pd.DataFrame(
+                    {"performance": [0, float("NaN"), float("NaN")]},
+                    index=[
+                        pd.Timestamp("2016-02-29T00:00Z"),
+                        pd.Timestamp("2020-02-29T01:00Z"),
+                        pd.Timestamp("2024-02-29T02:00Z"),
+                    ],
+                )
+            ],
             {pd.Timestamp("2020-02-29T01:00Z"), pd.Timestamp("2024-02-29T02:00Z")},
+        ),
+        (
+            [
+                pd.DataFrame(
+                    {
+                        "performance": [0, float("NaN"), float("NaN")],
+                        "other": [1, 2, 3],
+                    },
+                    index=[
+                        pd.Timestamp("2016-02-29T00:00Z"),
+                        pd.Timestamp("2020-02-29T01:00Z"),
+                        pd.Timestamp("2024-02-29T02:00Z"),
+                    ],
+                )
+            ],
+            set(),
+        ),
+        ([], set()),
+        (
+            [
+                pd.DataFrame(
+                    {"performance": [0, float("NaN"), float("NaN")]},
+                    index=[
+                        pd.Timestamp("2016-02-29T00:00Z"),
+                        pd.Timestamp("2020-02-29T01:00Z"),
+                        pd.Timestamp("2024-02-29T02:00Z"),
+                    ],
+                ),
+                pd.DataFrame(
+                    {"per": [0, float("NaN"), 99]},
+                    index=[
+                        pd.Timestamp("2016-02-29T00:00Z"),
+                        pd.Timestamp("2020-02-29T01:00Z"),
+                        pd.Timestamp("2024-02-29T02:00Z"),
+                    ],
+                ),
+            ],
+            {pd.Timestamp("2020-02-29T01:00Z")},
+        ),
+        (
+            [
+                pd.DataFrame(
+                    {"performance": [0, float("NaN"), float("NaN")]},
+                    index=[
+                        pd.Timestamp("2016-02-29T00:00Z"),
+                        pd.Timestamp("2020-02-29T01:00Z"),
+                        pd.Timestamp("2024-02-29T02:00Z"),
+                    ],
+                ),
+                pd.DataFrame(
+                    {"per": [0, float("NaN"), 99]},
+                    index=[
+                        pd.Timestamp("2016-02-29T00:00Z"),
+                        pd.Timestamp("2020-02-29T01:00Z"),
+                        pd.Timestamp("2024-02-29T02:00Z"),
+                    ],
+                ),
+                pd.DataFrame(
+                    {"per": [0, float("NaN"), float("NaN")]},
+                    index=[
+                        pd.Timestamp("2017-02-28T00:00Z"),
+                        pd.Timestamp("2020-02-29T01:00Z"),
+                        pd.Timestamp("2029-02-28T02:00Z"),
+                    ],
+                ),
+            ],
+            {pd.Timestamp("2020-02-29T01:00Z")},
         ),
     ],
 )
 def test_get_missing_leap_days(inp, exp):
     out = compute._get_missing_leap_days(inp)
     assert out == exp
+
+
+def test_compare_predicted_and_actual_leap_day_dropped(
+    auth0_id,
+    nocommit_transaction,
+    cec_system,
+    mocker,
+    system_id,
+):
+    actual_params = dict(
+        irradiance_type="poa",
+        temperature_type="cell",
+        weather_granularity="system",
+        performance_granularity="inverter",
+    )
+    pred_params = dict(
+        irradiance_type="standard",
+        temperature_type="module",
+        weather_granularity="system",
+        data_available="weather only",
+    )
+    save = mocker.patch("solarperformanceinsight_api.compute.save_results_to_db")
+    cat = pd.Timestamp.utcnow()
+    job_params = models.ComparePredictedActualJobParameters(
+        system_id=system_id,
+        time_parameters=dict(
+            start="2020-02-27T00:00:00-07:00",
+            end="2020-03-04T00:00:00-07:00",
+            step="30:00",
+            timezone="Etc/GMT+7",
+        ),
+        compare="predicted and actual performance",
+        predicted_data_parameters=pred_params,
+        actual_data_parameters=actual_params,
+    )
+    index = job_params.time_parameters._time_range
+    index.name = "time"
+    job = models.Job(
+        parameters=job_params,
+        system_definition=cec_system,
+    )
+    ids = [uuid1() for _ in range(len(job._data_items))]
+    data_objects = [
+        models.StoredJobDataMetadata(
+            object_id=ids[i],
+            object_type="job_data",
+            created_at=cat,
+            modified_at=cat,
+            definition=dict(
+                present=True,
+                filename="data",
+                data_format="application/vnd.apache.arrow.file",
+                type=di.type,
+                data_columns=di._data_cols,
+                schema_path=di.schema_path,
+            ),
+        )
+        for i, di in enumerate(job._data_items.values())
+    ]
+    stored_job = models.StoredJob(
+        object_id=uuid1(),
+        definition=job,
+        status=dict(
+            status="queued",
+            last_change=cat,
+        ),
+        created_at=cat,
+        modified_at=cat,
+        data_objects=data_objects,
+    )
+    weather = pd.DataFrame(
+        {
+            "module_temperature": 35.0,
+            "ghi": 1100,
+            "dni": 1000,
+            "dhi": 100,
+        },
+        index=index,
+    )
+    weather.loc[index.dayofyear == 60, :] = float("NaN")
+    weather.index.name = "time"
+
+    data = {}
+    for i, ((sp, type_), di) in enumerate(job._data_items.items()):
+        cols = set(di._data_cols) - {"time"}
+        if type_ == models.JobDataTypeEnum.actual_performance:
+            data[ids[i]] = pd.DataFrame(
+                {"performance": 1000 * (index.dayofyear == 60).astype(int)}, index=index
+            )  # zero expect on leap day
+        elif type_ == models.JobDataTypeEnum.predicted_performance:
+            data[ids[i]] = pd.DataFrame({"performance": 4000.0}, index=index)
+        elif type_ == models.JobDataTypeEnum.actual_weather:
+            data[ids[i]] = pd.DataFrame(
+                {
+                    "cell_temperature": 40.0,
+                    "poa_global": 1100,
+                    "poa_direct": 1000,
+                    "poa_diffuse": 100,
+                },
+                index=index,
+            )
+        elif type_ == models.JobDataTypeEnum.original_weather:
+            data[ids[i]] = weather[cols].copy()
+
+    def _get_data(job_id, data_id, si):
+        return data[data_id]
+
+    mocker.patch("solarperformanceinsight_api.compute._get_data", new=_get_data)
+
+    si = storage.StorageInterface(user=auth0_id)
+    compute.compare_predicted_and_actual(stored_job, si)
+    assert save.call_count == 1
+    reslist = save.call_args[0][1]
+
+    summary = reslist[-1]
+    assert summary.type == "actual vs weather adjusted reference"
+    iob = BytesIO(summary.data)
+    iob.seek(0)
+    summary_df = pd.read_feather(iob)
+    assert (summary_df["actual_energy"] == 0).all()

--- a/api/solarperformanceinsight_api/tests/test_compute.py
+++ b/api/solarperformanceinsight_api/tests/test_compute.py
@@ -1229,6 +1229,19 @@ def test_compare_predicted_and_actual_cec_module_temp_as_expected(
         (
             [
                 pd.DataFrame(
+                    {"performance": [float("NaN"), float("NaN"), 0]},
+                    index=[
+                        pd.Timestamp("2020-02-29T03:00Z"),
+                        pd.Timestamp("2020-02-29T23:00Z"),
+                        pd.Timestamp("2020-03-01T23:00Z"),
+                    ],
+                )
+            ],
+            {pd.Timestamp("2020-02-29T03:00Z"), pd.Timestamp("2020-02-29T23:00Z")},
+        ),
+        (
+            [
+                pd.DataFrame(
                     {"performance": [0, float("NaN"), 0]},
                     index=[
                         pd.Timestamp("2020-02-28T23:00-07:00"),
@@ -1302,6 +1315,21 @@ def test_compare_predicted_and_actual_cec_module_temp_as_expected(
                         pd.Timestamp("2016-02-29T00:00Z"),
                         pd.Timestamp("2020-02-29T01:00Z"),
                         pd.Timestamp("2024-02-29T02:00Z"),
+                    ],
+                )
+            ],
+            set(),
+        ),
+        (
+            [
+                pd.DataFrame(
+                    {
+                        "performance": [0, float("NaN"), float("NaN")],
+                    },
+                    index=[
+                        pd.Timestamp("2016-04-29T00:00Z"),
+                        pd.Timestamp("2020-04-29T01:00Z"),
+                        pd.Timestamp("2024-04-29T02:00Z"),
                     ],
                 )
             ],


### PR DESCRIPTION
closes #173

Does not differentiate between uploaded reference/predicted data that simply has no data for the leap day vs reference/predicted data that was shifted to match the actual data year